### PR TITLE
Implement advanced issue reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ test = [
 
 [tool.ruff]
 line-length = 101
+target-version = "py310"
 
 [tool.ruff.lint]
 exclude = ["tests/*", "docs/*"]

--- a/raillabel_providerkit/validation/__init__.py
+++ b/raillabel_providerkit/validation/__init__.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Package for validating raillabel data regarding the format requirements."""
 
+from .issue import Issue, IssueIdentifiers, IssueType
 from .validate_onthology.validate_onthology import validate_onthology
 from .validate_schema import validate_schema
 
-__all__ = ["validate_onthology", "validate_schema"]
+__all__ = ["Issue", "IssueIdentifiers", "IssueType", "validate_onthology", "validate_schema"]

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -30,4 +30,4 @@ class Issue:
 
     type: IssueType
     reason: str
-    identifiers: IssueIdentifiers
+    identifiers: IssueIdentifiers | list[str | int]

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -1,0 +1,32 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class IssueType(Enum):
+    """General classification of the issue."""
+
+    SCHEMA = "SchemaIssue"
+    EMPTY_FRAMES = "EmptyFramesIssue"
+    RAIL_SIDE = "RailSide"
+
+
+@dataclass
+class IssueIdentifiers:
+    """Information for locating an issue."""
+
+    annotation: str | None = None
+    frame: str | None = None
+    object: str | None = None
+    sensor: str | None = None
+
+
+@dataclass
+class Issue:
+    """An error that was found inside the scene."""
+
+    type: IssueType
+    reason: str
+    identifiers: IssueIdentifiers

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from uuid import UUID
 
 
 class IssueType(Enum):
@@ -17,9 +18,9 @@ class IssueType(Enum):
 class IssueIdentifiers:
     """Information for locating an issue."""
 
-    annotation: str | None = None
-    frame: str | None = None
-    object: str | None = None
+    annotation: UUID | None = None
+    frame: int | None = None
+    object: UUID | None = None
     sensor: str | None = None
 
 

--- a/raillabel_providerkit/validation/validate.py
+++ b/raillabel_providerkit/validation/validate.py
@@ -3,10 +3,12 @@
 
 from __future__ import annotations
 
+from raillabel_providerkit.validation import Issue
+
 from . import validate_schema
 
 
-def validate(scene_dict: dict) -> list[str]:
+def validate(scene_dict: dict) -> list[Issue]:
     """Validate a scene based on the Deutsche Bahn Requirements.
 
     Parameters
@@ -16,7 +18,7 @@ def validate(scene_dict: dict) -> list[str]:
 
     Returns
     -------
-    list[str]
+    list[Issue]
         list of all requirement errors in the scene. If an empty list is returned, then there are
         no errors present and the scene is valid.
 

--- a/raillabel_providerkit/validation/validate_empty_frames/validate_empty_frames.py
+++ b/raillabel_providerkit/validation/validate_empty_frames/validate_empty_frames.py
@@ -5,27 +5,25 @@ from __future__ import annotations
 
 import raillabel
 
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
 
-def validate_empty_frames(scene: raillabel.Scene) -> list[str]:
+
+def validate_empty_frames(scene: raillabel.Scene) -> list[Issue]:
     """Validate whether all frames of a scene have at least one annotation.
 
-    Parameters
-    ----------
-    scene : raillabel.Scene
-        Scene, that should be validated.
-
-    Returns
-    -------
-    list[str]
-        list of all empty frame errors in the scene. If an empty list is returned, then there are no
-        errors present.
-
+    If an empty list is returned, then there are no errors present.
     """
-    errors: list[str] = []
+    errors = []
 
     for frame_uid, frame in scene.frames.items():
         if _is_frame_empty(frame):
-            errors.append("Frame " + str(frame_uid) + " has no annotations!")
+            errors.append(
+                Issue(
+                    type=IssueType.EMPTY_FRAMES,
+                    reason="This frame has no annotations.",
+                    identifiers=IssueIdentifiers(frame=frame_uid),
+                )
+            )
 
     return errors
 

--- a/raillabel_providerkit/validation/validate_schema/validate_schema.py
+++ b/raillabel_providerkit/validation/validate_schema/validate_schema.py
@@ -8,8 +8,10 @@ import json
 from pydantic_core import ValidationError
 from raillabel.json_format import JSONScene
 
+from raillabel_providerkit.validation import Issue, IssueType
 
-def validate_schema(data: dict) -> list[str]:
+
+def validate_schema(data: dict) -> list[Issue]:
     """Validate a scene for adherence to the raillabel schema."""
     try:
         JSONScene(**data)
@@ -19,42 +21,44 @@ def validate_schema(data: dict) -> list[str]:
         return []
 
 
-def _make_errors_readable(errors: ValidationError) -> list[str]:  # noqa: C901
+def _make_errors_readable(errors: ValidationError) -> list[Issue]:  # noqa: C901
     readable_errors = []
     for error in json.loads(errors.json()):
         match error["type"]:
             case "missing":
-                readable_errors.append(_convert_missing_error_to_string(error))
+                readable_errors.append(_convert_missing_error_to_issue(error))
 
             case "extra_forbidden":
-                readable_errors.append(_convert_unexpected_field_error_to_string(error))
+                readable_errors.append(_convert_unexpected_field_error_to_issue(error))
 
             case "literal_error":
-                readable_errors.append(_convert_literal_error_to_string(error))
+                readable_errors.append(_convert_literal_error_to_issue(error))
 
             case "bool_type" | "bool_parsing":
-                readable_errors.append(_convert_false_type_error_to_string(error, "bool"))
+                readable_errors.append(_convert_false_type_error_to_issue(error, "bool"))
 
             case "int_type" | "int_parsing" | "int_from_float":
-                readable_errors.append(_convert_false_type_error_to_string(error, "int"))
+                readable_errors.append(_convert_false_type_error_to_issue(error, "int"))
 
             case "decimal_type" | "decimal_parsing":
-                readable_errors.append(_convert_false_type_error_to_string(error, "Decimal"))
+                readable_errors.append(_convert_false_type_error_to_issue(error, "Decimal"))
 
             case "string_type" | "string_parsing":
-                readable_errors.append(_convert_false_type_error_to_string(error, "str"))
+                readable_errors.append(_convert_false_type_error_to_issue(error, "str"))
 
             case "float_type" | "float_parsing":
-                readable_errors.append(_convert_false_type_error_to_string(error, "float"))
+                readable_errors.append(_convert_false_type_error_to_issue(error, "float"))
 
             case "uuid_type" | "uuid_parsing":
-                readable_errors.append(_convert_false_type_error_to_string(error, "UUID"))
+                readable_errors.append(_convert_false_type_error_to_issue(error, "UUID"))
 
             case "too_long":
-                readable_errors.append(_convert_too_long_error_to_string(error))
+                readable_errors.append(_convert_too_long_error_to_issue(error))
 
             case _:
-                readable_errors.append(str(error))
+                readable_errors.append(
+                    Issue(type=IssueType.SCHEMA, identifiers=[], reason=str(error))
+                )
 
     return readable_errors
 
@@ -66,32 +70,49 @@ def _build_error_path(loc: list[str]) -> str:
     return path
 
 
-def _convert_missing_error_to_string(error: dict) -> str:
-    return f"{_build_error_path(error['loc'][:-1])}: required field '{error['loc'][-1]}' is missing."
-
-
-def _convert_unexpected_field_error_to_string(error: dict) -> str:
-    return f"{_build_error_path(error['loc'][:-1])}: found unexpected field '{error['loc'][-1]}'."
-
-
-def _convert_literal_error_to_string(error: dict) -> str:
-    return (
-        f"{_build_error_path(error['loc'])}: value '{error['input']}' does not match allowed values "
-        f"({error['ctx']['expected']})."
+def _convert_missing_error_to_issue(error: dict) -> Issue:
+    return Issue(
+        type=IssueType.SCHEMA,
+        identifiers=error["loc"][:-1],
+        reason=f"Required field '{error['loc'][-1]}' is missing.",
     )
 
 
-def _convert_false_type_error_to_string(error: dict, target_type: str) -> str:
-    if "[key]" in error["loc"]:
-        error_path = _build_error_path(error["loc"][:-2])
-    else:
-        error_path = _build_error_path(error["loc"])
+def _convert_unexpected_field_error_to_issue(error: dict) -> Issue:
+    return Issue(
+        type=IssueType.SCHEMA,
+        identifiers=error["loc"][:-1],
+        reason=f"Found unexpected field '{error['loc'][-1]}'.",
+    )
 
-    return f"{error_path}: value '{error['input']}' could not be interpreted " f"as {target_type}."
+
+def _convert_literal_error_to_issue(error: dict) -> Issue:
+    return Issue(
+        type=IssueType.SCHEMA,
+        identifiers=error["loc"],
+        reason=(
+            f"Value '{error['input']}' does not match allowed values"
+            f" ({error['ctx']['expected']})."
+        ),
+    )
 
 
-def _convert_too_long_error_to_string(error: dict) -> str:
-    return (
-        f"{_build_error_path(error['loc'])}: should have length of {error['ctx']['actual_length']} "
-        f"but has length of {error['ctx']['max_length']}."
+def _convert_false_type_error_to_issue(error: dict, target_type: str) -> Issue:
+    error_path = error["loc"][:-2] if "[key]" in error["loc"] else error["loc"]
+
+    return Issue(
+        type=IssueType.SCHEMA,
+        identifiers=error_path,
+        reason=f"Value '{error['input']}' could not be interpreted as {target_type}.",
+    )
+
+
+def _convert_too_long_error_to_issue(error: dict) -> Issue:
+    return Issue(
+        type=IssueType.SCHEMA,
+        identifiers=error["loc"],
+        reason=(
+            f"Should have length of {error['ctx']['actual_length']} but has length of "
+            f"{error['ctx']['max_length']}."
+        ),
     )

--- a/tests/test_raillabel_providerkit/validation/validate_empty_frame/test_validate_empty_frames.py
+++ b/tests/test_raillabel_providerkit/validation/validate_empty_frame/test_validate_empty_frames.py
@@ -7,6 +7,7 @@ from raillabel_providerkit.validation.validate_empty_frames.validate_empty_frame
     _is_frame_empty,
     validate_empty_frames,
 )
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
 
 
 def test_is_frame_empty__true(empty_frame):
@@ -59,10 +60,12 @@ def test_validate_empty_frames__error_message_contains_indentifying_info(empty_f
         0: empty_frame,
     }
 
-    error_message = validate_empty_frames(scene)[0].lower()
-    assert "frame" in error_message
-    assert "0" in error_message
-    assert "empty" in error_message or "no annotations" in error_message
+    actual = validate_empty_frames(scene)[0]
+    assert actual == Issue(
+        type=IssueType.EMPTY_FRAMES,
+        reason="This frame has no annotations.",
+        identifiers=IssueIdentifiers(frame=0),
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_raillabel_providerkit/validation/validate_rail_side/test_validate_rail_side.py
+++ b/tests/test_raillabel_providerkit/validation/validate_rail_side/test_validate_rail_side.py
@@ -1,6 +1,8 @@
 # Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from uuid import UUID
+
 import pytest
 from raillabel.format import Poly2d, Point2d
 from raillabel.scene_builder import SceneBuilder
@@ -9,6 +11,7 @@ from raillabel_providerkit.validation.validate_rail_side.validate_rail_side impo
     validate_rail_side,
     _count_rails_per_track_in_frame,
 )
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
 
 
 def test_count_rails_per_track_in_frame__empty(empty_frame):
@@ -155,6 +158,7 @@ def test_validate_rail_side__no_errors(ignore_uuid):
 
 
 def test_validate_rail_side__rail_sides_switched(ignore_uuid):
+    SENSOR_ID = "rgb_center"
     scene = (
         SceneBuilder.empty()
         .add_annotation(
@@ -169,7 +173,7 @@ def test_validate_rail_side__rail_sides_switched(ignore_uuid):
                 sensor_id="IGNORE_THIS",
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .add_annotation(
             annotation=Poly2d(
@@ -183,16 +187,25 @@ def test_validate_rail_side__rail_sides_switched(ignore_uuid):
                 sensor_id="IGNORE_THIS",
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .result
     )
 
     actual = validate_rail_side(scene)
-    assert len(actual) == 1
+    assert actual == [
+        Issue(
+            type=IssueType.RAIL_SIDE,
+            reason="The left and right rails of this track are swapped.",
+            identifiers=IssueIdentifiers(
+                frame=1, sensor=SENSOR_ID, object=UUID("5c59aad4-0000-4000-0000-000000000000")
+            ),
+        )
+    ]
 
 
 def test_validate_rail_side__rail_sides_intersect_at_top(ignore_uuid):
+    SENSOR_ID = "rgb_center"
     scene = (
         SceneBuilder.empty()
         .add_annotation(
@@ -209,7 +222,7 @@ def test_validate_rail_side__rail_sides_intersect_at_top(ignore_uuid):
                 sensor_id="IGNORE_THIS",
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .add_annotation(
             annotation=Poly2d(
@@ -225,13 +238,21 @@ def test_validate_rail_side__rail_sides_intersect_at_top(ignore_uuid):
                 sensor_id="IGNORE_THIS",
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .result
     )
 
     actual = validate_rail_side(scene)
-    assert len(actual) == 1
+    assert actual == [
+        Issue(
+            type=IssueType.RAIL_SIDE,
+            reason="The left and right rails of this track intersect.",
+            identifiers=IssueIdentifiers(
+                frame=1, sensor=SENSOR_ID, object=UUID("5c59aad4-0000-4000-0000-000000000000")
+            ),
+        )
+    ]
 
 
 def test_validate_rail_side__rail_sides_correct_with_early_end_of_one_side(ignore_uuid):
@@ -276,6 +297,7 @@ def test_validate_rail_side__rail_sides_correct_with_early_end_of_one_side(ignor
 
 
 def test_validate_rail_side__two_left_rails(ignore_uuid):
+    SENSOR_ID = "rgb_center"
     scene = (
         SceneBuilder.empty()
         .add_annotation(
@@ -290,7 +312,7 @@ def test_validate_rail_side__two_left_rails(ignore_uuid):
                 sensor_id="IGNORE_THIS",
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .add_annotation(
             annotation=Poly2d(
@@ -304,16 +326,25 @@ def test_validate_rail_side__two_left_rails(ignore_uuid):
                 sensor_id="IGNORE_THIS",
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .result
     )
 
     actual = validate_rail_side(scene)
-    assert len(actual) == 1
+    assert actual == [
+        Issue(
+            type=IssueType.RAIL_SIDE,
+            reason="This track has 2 left rails.",
+            identifiers=IssueIdentifiers(
+                frame=1, sensor=SENSOR_ID, object=UUID("5c59aad4-0000-4000-0000-000000000000")
+            ),
+        )
+    ]
 
 
 def test_validate_rail_side__two_right_rails(ignore_uuid):
+    SENSOR_ID = "rgb_center"
     scene = (
         SceneBuilder.empty()
         .add_annotation(
@@ -325,10 +356,10 @@ def test_validate_rail_side__two_right_rails(ignore_uuid):
                 closed=False,
                 attributes={"railSide": "rightRail"},
                 object_id=ignore_uuid,
-                sensor_id="IGNORE_THIS",
+                sensor_id=SENSOR_ID,
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .add_annotation(
             annotation=Poly2d(
@@ -339,16 +370,24 @@ def test_validate_rail_side__two_right_rails(ignore_uuid):
                 closed=False,
                 attributes={"railSide": "rightRail"},
                 object_id=ignore_uuid,
-                sensor_id="IGNORE_THIS",
+                sensor_id=SENSOR_ID,
             ),
             object_name="track_0001",
-            sensor_id="rgb_center",
+            sensor_id=SENSOR_ID,
         )
         .result
     )
 
     actual = validate_rail_side(scene)
-    assert len(actual) == 1
+    assert actual == [
+        Issue(
+            type=IssueType.RAIL_SIDE,
+            reason="This track has 2 right rails.",
+            identifiers=IssueIdentifiers(
+                frame=1, sensor=SENSOR_ID, object=UUID("5c59aad4-0000-4000-0000-000000000000")
+            ),
+        )
+    ]
 
 
 def test_validate_rail_side__two_sensors_with_two_right_rails_each(ignore_uuid):
@@ -460,4 +499,4 @@ def test_validate_rail_side__two_sensors_with_one_right_rail_each(ignore_uuid):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__, "--disable-pytest-warnings", "--cache-clear", "-v"])
+    pytest.main([__file__, "-vv"])


### PR DESCRIPTION
This PR changes the output of the validators from simple issue strings to `Issue` objects containing `IssueIdentifiers`. To that end, each validator's tests and implementation have been refactored.

The `validate_onthology` functionality has intentionally been ignored as this and its tests need to be refactored/reimplemented in a future PR.