### PR TITLE
Complete refactor of validate_onthology

### DIFF
--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -10,6 +10,7 @@ class IssueType(Enum):
     """General classification of the issue."""
 
     SCHEMA = "SchemaIssue"
+    ATTRIBUTE_TYPE = "AttributeTypeIssue"
     EMPTY_FRAMES = "EmptyFramesIssue"
     RAIL_SIDE = "RailSide"
 

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -11,6 +11,7 @@ class IssueType(Enum):
 
     SCHEMA = "SchemaIssue"
     ATTRIBUTE_TYPE = "AttributeTypeIssue"
+    ATTRIBUTE_VALUE = "AttributeValueIssue"
     EMPTY_FRAMES = "EmptyFramesIssue"
     RAIL_SIDE = "RailSide"
 

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -25,6 +25,7 @@ class IssueIdentifiers:
     """Information for locating an issue."""
 
     annotation: UUID | None = None
+    attribute: str | None = None
     frame: int | None = None
     object: UUID | None = None
     sensor: str | None = None

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -10,7 +10,9 @@ class IssueType(Enum):
     """General classification of the issue."""
 
     SCHEMA = "SchemaIssue"
+    ATTRIBUTE_MISSING = "AttributeMissing"
     ATTRIBUTE_TYPE = "AttributeTypeIssue"
+    ATTRIBUTE_UNDEFINED = "AttributeUndefined"
     ATTRIBUTE_VALUE = "AttributeValueIssue"
     EMPTY_FRAMES = "EmptyFramesIssue"
     RAIL_SIDE = "RailSide"

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -15,6 +15,7 @@ class IssueType(Enum):
     ATTRIBUTE_UNDEFINED = "AttributeUndefined"
     ATTRIBUTE_VALUE = "AttributeValueIssue"
     EMPTY_FRAMES = "EmptyFramesIssue"
+    OBJECT_TYPE_UNDEFINED = "ObjectTypeUndefined"
     RAIL_SIDE = "RailSide"
 
 

--- a/raillabel_providerkit/validation/validate.py
+++ b/raillabel_providerkit/validation/validate.py
@@ -33,7 +33,7 @@ def validate(
         scene_source: The scene either as a dictionary or as a Path to the scene source file.
         onthology_source: The dataset onthology as a dictionary or as a Path to the onthology YAML
             file. If not None, issues are returned if the scene contains annotations with invalid
-            attributes or object types. Default is True.
+            attributes or object types. Default is None.
         validate_for_empty_frames (optional): If True, issues are returned if the scene contains
             frames without annotations. Default is True.
         validate_for_rail_side_order: If True, issues are returned if the scene contains track with

--- a/raillabel_providerkit/validation/validate.py
+++ b/raillabel_providerkit/validation/validate.py
@@ -11,11 +11,12 @@ from raillabel.json_format import JSONScene
 
 from raillabel_providerkit.validation import Issue
 
-from . import validate_empty_frames, validate_rail_side, validate_schema
+from . import validate_empty_frames, validate_onthology, validate_rail_side, validate_schema
 
 
 def validate(
     scene_source: dict | Path,
+    onthology_source: dict | Path | None = None,
     validate_for_empty_frames: bool = True,
     validate_for_rail_side_order: bool = True,
 ) -> list[Issue]:
@@ -23,6 +24,9 @@ def validate(
 
     Args:
         scene_source: The scene either as a dictionary or as a Path to the scene source file.
+        onthology_source: The dataset onthology as a dictionary or as a Path to the onthology YAML
+            file. If not None, issues are returned if the scene contains annotations with invalid
+            attributes or object types. Default is True.
         validate_for_empty_frames (optional): If True, issues are returned if the scene contains
             frames without annotations. Default is True.
         validate_for_rail_side_order: If True, issues are returned if the scene contains track with
@@ -42,6 +46,9 @@ def validate(
 
     scene = Scene.from_json(JSONScene(**scene_source))
     errors = []
+
+    if onthology_source is not None:
+        errors.extend(validate_onthology(scene, onthology_source))
 
     if validate_for_empty_frames:
         errors.extend(validate_empty_frames(scene))

--- a/raillabel_providerkit/validation/validate.py
+++ b/raillabel_providerkit/validation/validate.py
@@ -11,7 +11,13 @@ from raillabel.json_format import JSONScene
 
 from raillabel_providerkit.validation import Issue
 
-from . import validate_empty_frames, validate_missing_ego_track, validate_onthology, validate_rail_side, validate_schema
+from . import (
+    validate_empty_frames,
+    validate_missing_ego_track,
+    validate_onthology,
+    validate_rail_side,
+    validate_schema,
+)
 
 
 def validate(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
@@ -14,12 +14,12 @@ from pkgutil import iter_modules
 class _Attribute(abc.ABC):
     @classmethod
     @abc.abstractmethod
-    def supports(cls, data_dict: dict) -> bool:
+    def supports(cls, data: dict | str) -> bool:
         raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
-    def fromdict(cls, data_dict: dict) -> type[_Attribute]:
+    def fromdict(cls, data: dict | str) -> _Attribute:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -48,5 +48,5 @@ def _collect_attribute_classes() -> None:
                 ATTRIBUTE_CLASSES.append(class_)
 
 
-ATTRIBUTE_CLASSES = []
+ATTRIBUTE_CLASSES: list[type[_Attribute]] = []
 _collect_attribute_classes()

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
@@ -21,12 +21,12 @@ class _Attribute(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def supports(cls, data: dict) -> bool:
+    def supports(cls, attribute_dict: dict) -> bool:
         raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
-    def fromdict(cls, data: dict) -> _Attribute:
+    def fromdict(cls, attribute_dict: dict) -> _Attribute:
         raise NotImplementedError
 
     @abc.abstractmethod

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
@@ -15,6 +15,19 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._sco
 
 @dataclass
 class _Attribute(abc.ABC):
+    """Attribute definition of an object class.
+
+    Parameters
+    ----------
+    optional: bool
+        Whether the attribute is required to exist in every annotation of the object class.
+    scope: _Scope
+        The scope all attributes following this definition have to adhere to.
+    sensor_types: list[str]
+        The sensors for which annotations are allowed to have this attribute.
+
+    """
+
     optional: bool
     scope: _Scope
     sensor_types: list[str]

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
@@ -9,23 +9,33 @@ from inspect import isclass
 from pathlib import Path
 from pkgutil import iter_modules
 
+from raillabel_providerkit.validation import Issue, IssueIdentifiers
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+
 
 @dataclass
 class _Attribute(abc.ABC):
+    optional: bool
+    scope: _Scope
+    sensor_types: list[str] | None
+
     @classmethod
     @abc.abstractmethod
-    def supports(cls, data: dict | str) -> bool:
+    def supports(cls, data: dict) -> bool:
         raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
-    def fromdict(cls, data: dict | str) -> _Attribute:
+    def fromdict(cls, data: dict) -> _Attribute:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def check(
-        self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str
-    ) -> list[str]:
+    def check_type_and_value(
+        self,
+        attribute_name: str,
+        attribute_value: bool | float | str | list,
+        identifiers: IssueIdentifiers,
+    ) -> list[Issue]:
         raise NotImplementedError
 
 

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_attribute_abc.py
@@ -17,7 +17,7 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._sco
 class _Attribute(abc.ABC):
     optional: bool
     scope: _Scope
-    sensor_types: list[str] | None
+    sensor_types: list[str]
 
     @classmethod
     @abc.abstractmethod

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_boolean_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_boolean_attribute.py
@@ -5,28 +5,49 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import (
+    _Scope,
+)
+
 from ._attribute_abc import _Attribute
 
 
 @dataclass
 class _BooleanAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict | str) -> bool:
-        return data == "boolean"
+    def supports(cls, data: dict) -> bool:
+        return "attribute_type" in data and data["attribute_type"] == "boolean"
 
     @classmethod
-    def fromdict(cls, _: dict | str) -> _BooleanAttribute:
-        return _BooleanAttribute()
+    def fromdict(cls, data: dict) -> _BooleanAttribute:
+        if not cls.supports(data):
+            raise ValueError
 
-    def check(
-        self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str
-    ) -> list[str]:
+        return _BooleanAttribute(
+            optional=data.get("optional", False),
+            scope=_Scope(data["scope"]),
+            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+        )
+
+    def check_type_and_value(
+        self,
+        attribute_name: str,
+        attribute_value: bool | float | str | list,
+        identifiers: IssueIdentifiers,
+    ) -> list[Issue]:
         errors = []
 
         if type(attribute_value) is not bool:
             errors.append(
-                f"Attribute '{attribute_name}' of annotation {annotation_id} is of type "
-                f"'{attribute_value.__class__.__name__}' (should be 'bool')."
+                Issue(
+                    type=IssueType.ATTRIBUTE_TYPE,
+                    reason=(
+                        f"Attribute '{attribute_name}' is of type"
+                        f" {attribute_value.__class__.__name__} (should be 'bool')."
+                    ),
+                    identifiers=identifiers,
+                )
             )
 
         return errors

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_boolean_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_boolean_attribute.py
@@ -11,11 +11,11 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _BooleanAttribute(_Attribute):
     @classmethod
-    def supports(cls, data_dict: dict) -> bool:
-        return data_dict == "boolean"
+    def supports(cls, data: dict | str) -> bool:
+        return data == "boolean"
 
     @classmethod
-    def fromdict(cls, _: dict) -> _BooleanAttribute:
+    def fromdict(cls, _: dict | str) -> _BooleanAttribute:
         return _BooleanAttribute()
 
     def check(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_boolean_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_boolean_attribute.py
@@ -16,18 +16,18 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _BooleanAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict) -> bool:
-        return "attribute_type" in data and data["attribute_type"] == "boolean"
+    def supports(cls, attribute_dict: dict) -> bool:
+        return "attribute_type" in attribute_dict and attribute_dict["attribute_type"] == "boolean"
 
     @classmethod
-    def fromdict(cls, data: dict) -> _BooleanAttribute:
-        if not cls.supports(data):
+    def fromdict(cls, attribute_dict: dict) -> _BooleanAttribute:
+        if not cls.supports(attribute_dict):
             raise ValueError
 
         return _BooleanAttribute(
-            optional=data.get("optional", False),
-            scope=_Scope(data["scope"]),
-            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict["scope"]),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
         )
 
     def check_type_and_value(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_integer_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_integer_attribute.py
@@ -16,18 +16,18 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _IntegerAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict) -> bool:
-        return "attribute_type" in data and data["attribute_type"] == "integer"
+    def supports(cls, attribute_dict: dict) -> bool:
+        return "attribute_type" in attribute_dict and attribute_dict["attribute_type"] == "integer"
 
     @classmethod
-    def fromdict(cls, data: dict) -> _IntegerAttribute:
-        if not cls.supports(data):
+    def fromdict(cls, attribute_dict: dict) -> _IntegerAttribute:
+        if not cls.supports(attribute_dict):
             raise ValueError
 
         return _IntegerAttribute(
-            optional=data.get("optional", False),
-            scope=_Scope(data["scope"]),
-            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict["scope"]),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
         )
 
     def check_type_and_value(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_integer_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_integer_attribute.py
@@ -11,11 +11,11 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _IntegerAttribute(_Attribute):
     @classmethod
-    def supports(cls, data_dict: dict) -> bool:
-        return data_dict == "integer"
+    def supports(cls, data: dict | str) -> bool:
+        return data == "integer"
 
     @classmethod
-    def fromdict(cls, _: dict) -> _IntegerAttribute:
+    def fromdict(cls, _: dict | str) -> _IntegerAttribute:
         return _IntegerAttribute()
 
     def check(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_integer_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_integer_attribute.py
@@ -18,7 +18,7 @@ class _IntegerAttribute(_Attribute):
     def fromdict(cls, _: dict | str) -> _IntegerAttribute:
         return _IntegerAttribute()
 
-    def check(
+    def check_type_and_value(
         self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str
     ) -> list[str]:
         errors = []

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_reference_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_reference_attribute.py
@@ -1,0 +1,68 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass
+from uuid import UUID
+
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import (
+    _Scope,
+)
+
+from ._attribute_abc import _Attribute
+
+
+@dataclass
+class _MultiReferenceAttribute(_Attribute):
+    @classmethod
+    def supports(cls, data: dict) -> bool:
+        return "attribute_type" in data and data["attribute_type"] == "multi-reference"
+
+    @classmethod
+    def fromdict(cls, data: dict) -> _MultiReferenceAttribute:
+        if not cls.supports(data):
+            raise ValueError
+
+        return _MultiReferenceAttribute(
+            optional=data.get("optional", False),
+            scope=_Scope(data["scope"]),
+            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+        )
+
+    def check_type_and_value(
+        self,
+        attribute_name: str,
+        attribute_values: bool | float | str | list,
+        identifiers: IssueIdentifiers,
+    ) -> list[Issue]:
+        if type(attribute_values) is not list:
+            return [
+                Issue(
+                    type=IssueType.ATTRIBUTE_TYPE,
+                    reason=(
+                        f"Attribute '{attribute_name}' is of type"
+                        f" {attribute_values.__class__.__name__} (should be 'list')."
+                    ),
+                    identifiers=identifiers,
+                )
+            ]
+
+        attribute_value: t.Any
+        try:
+            for attribute_value in attribute_values:
+                UUID(attribute_value)
+        except (ValueError, AttributeError):
+            return [
+                Issue(
+                    type=IssueType.ATTRIBUTE_VALUE,
+                    reason=(
+                        f"Attribute '{attribute_name}' has a non-UUID value '{attribute_value}'."
+                    ),
+                    identifiers=identifiers,
+                )
+            ]
+
+        return []

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_reference_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_reference_attribute.py
@@ -18,18 +18,21 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _MultiReferenceAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict) -> bool:
-        return "attribute_type" in data and data["attribute_type"] == "multi-reference"
+    def supports(cls, attribute_dict: dict) -> bool:
+        return (
+            "attribute_type" in attribute_dict
+            and attribute_dict["attribute_type"] == "multi-reference"
+        )
 
     @classmethod
-    def fromdict(cls, data: dict) -> _MultiReferenceAttribute:
-        if not cls.supports(data):
+    def fromdict(cls, attribute_dict: dict) -> _MultiReferenceAttribute:
+        if not cls.supports(attribute_dict):
             raise ValueError
 
         return _MultiReferenceAttribute(
-            optional=data.get("optional", False),
-            scope=_Scope(data["scope"]),
-            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict["scope"]),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
         )
 
     def check_type_and_value(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_select_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_select_attribute.py
@@ -18,24 +18,24 @@ class _MultiSelectAttribute(_Attribute):
     options: set[str]
 
     @classmethod
-    def supports(cls, data: dict) -> bool:
+    def supports(cls, attribute_dict: dict) -> bool:
         return (
-            "attribute_type" in data
-            and type(data["attribute_type"]) is dict
-            and "type" in data["attribute_type"]
-            and data["attribute_type"]["type"] == "multi-select"
+            "attribute_type" in attribute_dict
+            and type(attribute_dict["attribute_type"]) is dict
+            and "type" in attribute_dict["attribute_type"]
+            and attribute_dict["attribute_type"]["type"] == "multi-select"
         )
 
     @classmethod
-    def fromdict(cls, data: dict) -> _MultiSelectAttribute:
-        if not cls.supports(data):
+    def fromdict(cls, attribute_dict: dict) -> _MultiSelectAttribute:
+        if not cls.supports(attribute_dict):
             raise ValueError
 
         return _MultiSelectAttribute(
-            optional=data.get("optional", False),
-            scope=_Scope(data["scope"]),
-            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
-            options=set(data["attribute_type"]["options"]),
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict["scope"]),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
+            options=set(attribute_dict["attribute_type"]["options"]),
         )
 
     def check_type_and_value(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_select_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_select_attribute.py
@@ -23,7 +23,7 @@ class _MultiSelectAttribute(_Attribute):
 
         return _MultiSelectAttribute(options=set(data["options"]))
 
-    def check(
+    def check_type_and_value(
         self, attribute_name: str, attribute_values: bool | float | str | list, annotation_id: str
     ) -> list[str]:
         if type(attribute_values) is not list:

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_select_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_multi_select_attribute.py
@@ -13,14 +13,15 @@ class _MultiSelectAttribute(_Attribute):
     options: set[str]
 
     @classmethod
-    def supports(cls, data_dict: dict) -> bool:
-        return (
-            type(data_dict) is dict and "type" in data_dict and data_dict["type"] == "multi-select"
-        )
+    def supports(cls, data: dict | str) -> bool:
+        return type(data) is dict and "type" in data and data["type"] == "multi-select"
 
     @classmethod
-    def fromdict(cls, data_dict: dict) -> _MultiSelectAttribute:
-        return _MultiSelectAttribute(options=set(data_dict["options"]))
+    def fromdict(cls, data: dict | str) -> _MultiSelectAttribute:
+        if isinstance(data, str):
+            raise TypeError
+
+        return _MultiSelectAttribute(options=set(data["options"]))
 
     def check(
         self, attribute_name: str, attribute_values: bool | float | str | list, annotation_id: str

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import (
+    _Scope,
+)
+
 from ._attribute_abc import _Attribute
 
 
@@ -13,29 +18,54 @@ class _SingleSelectAttribute(_Attribute):
     options: set[str]
 
     @classmethod
-    def supports(cls, data: dict | str) -> bool:
-        return type(data) is dict and "type" in data and data["type"] == "single-select"
+    def supports(cls, data: dict) -> bool:
+        return (
+            "attribute_type" in data
+            and type(data["attribute_type"]) is dict
+            and "type" in data["attribute_type"]
+            and data["attribute_type"]["type"] == "single-select"
+        )
 
     @classmethod
-    def fromdict(cls, data: dict | str) -> _SingleSelectAttribute:
-        if isinstance(data, str):
-            raise TypeError
+    def fromdict(cls, data: dict) -> _SingleSelectAttribute:
+        if not cls.supports(data):
+            raise ValueError
 
-        return _SingleSelectAttribute(options=set(data["options"]))
+        return _SingleSelectAttribute(
+            optional=data.get("optional", False),
+            scope=_Scope(data["scope"]),
+            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+            options=set(data["attribute_type"]["options"]),
+        )
 
     def check_type_and_value(
-        self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str
-    ) -> list[str]:
+        self,
+        attribute_name: str,
+        attribute_value: bool | float | str | list,
+        identifiers: IssueIdentifiers,
+    ) -> list[Issue]:
         if type(attribute_value) is not str:
             return [
-                f"Attribute '{attribute_name}' of annotation {annotation_id} is of type "
-                f"'{attribute_value.__class__.__name__}' (should be 'str')."
+                Issue(
+                    type=IssueType.ATTRIBUTE_TYPE,
+                    reason=(
+                        f"Attribute '{attribute_name}' is of type"
+                        f" {attribute_value.__class__.__name__} (should be 'str')."
+                    ),
+                    identifiers=identifiers,
+                )
             ]
 
         if attribute_value not in self.options:
             return [
-                f"Attribute '{attribute_name}' of annotation {annotation_id} has an undefined "
-                f"value '{attribute_value}' (defined options: {self._stringify_options()})."
+                Issue(
+                    type=IssueType.ATTRIBUTE_VALUE,
+                    reason=(
+                        f"Attribute '{attribute_name}' has an undefined value"
+                        f" '{attribute_value}' (defined options: {self._stringify_options()})."
+                    ),
+                    identifiers=identifiers,
+                )
             ]
 
         return []

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
@@ -18,24 +18,24 @@ class _SingleSelectAttribute(_Attribute):
     options: set[str]
 
     @classmethod
-    def supports(cls, data: dict) -> bool:
+    def supports(cls, attribute_dict: dict) -> bool:
         return (
-            "attribute_type" in data
-            and type(data["attribute_type"]) is dict
-            and "type" in data["attribute_type"]
-            and data["attribute_type"]["type"] == "single-select"
+            "attribute_type" in attribute_dict
+            and type(attribute_dict["attribute_type"]) is dict
+            and "type" in attribute_dict["attribute_type"]
+            and attribute_dict["attribute_type"]["type"] == "single-select"
         )
 
     @classmethod
-    def fromdict(cls, data: dict) -> _SingleSelectAttribute:
-        if not cls.supports(data):
+    def fromdict(cls, attribute_dict: dict) -> _SingleSelectAttribute:
+        if not cls.supports(attribute_dict):
             raise ValueError
 
         return _SingleSelectAttribute(
-            optional=data.get("optional", False),
-            scope=_Scope(data["scope"]),
-            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
-            options=set(data["attribute_type"]["options"]),
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict["scope"]),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
+            options=set(attribute_dict["attribute_type"]["options"]),
         )
 
     def check_type_and_value(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
@@ -13,14 +13,15 @@ class _SingleSelectAttribute(_Attribute):
     options: set[str]
 
     @classmethod
-    def supports(cls, data_dict: dict) -> bool:
-        return (
-            type(data_dict) is dict and "type" in data_dict and data_dict["type"] == "single-select"
-        )
+    def supports(cls, data: dict | str) -> bool:
+        return type(data) is dict and "type" in data and data["type"] == "single-select"
 
     @classmethod
-    def fromdict(cls, data_dict: dict) -> _SingleSelectAttribute:
-        return _SingleSelectAttribute(options=set(data_dict["options"]))
+    def fromdict(cls, data: dict | str) -> _SingleSelectAttribute:
+        if isinstance(data, str):
+            raise TypeError
+
+        return _SingleSelectAttribute(options=set(data["options"]))
 
     def check(
         self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_single_select_attribute.py
@@ -23,7 +23,7 @@ class _SingleSelectAttribute(_Attribute):
 
         return _SingleSelectAttribute(options=set(data["options"]))
 
-    def check(
+    def check_type_and_value(
         self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str
     ) -> list[str]:
         if type(attribute_value) is not str:

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
@@ -16,18 +16,18 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _StringAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict) -> bool:
-        return "attribute_type" in data and data["attribute_type"] == "string"
+    def supports(cls, attribute_dict: dict) -> bool:
+        return "attribute_type" in attribute_dict and attribute_dict["attribute_type"] == "string"
 
     @classmethod
-    def fromdict(cls, data: dict) -> _StringAttribute:
-        if not cls.supports(data):
+    def fromdict(cls, attribute_dict: dict) -> _StringAttribute:
+        if not cls.supports(attribute_dict):
             raise ValueError
 
         return _StringAttribute(
-            optional=data.get("optional", False),
-            scope=_Scope(data["scope"]),
-            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict["scope"]),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
         )
 
     def check_type_and_value(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
@@ -18,7 +18,7 @@ class _StringAttribute(_Attribute):
     def fromdict(cls, _: dict | str) -> _StringAttribute:
         return _StringAttribute()
 
-    def check(
+    def check_type_and_value(
         self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str
     ) -> list[str]:
         errors = []

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
@@ -11,11 +11,11 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _StringAttribute(_Attribute):
     @classmethod
-    def supports(cls, data_dict: dict) -> bool:
-        return data_dict == "string"
+    def supports(cls, data: dict | str) -> bool:
+        return data == "string"
 
     @classmethod
-    def fromdict(cls, _: dict) -> _StringAttribute:
+    def fromdict(cls, _: dict | str) -> _StringAttribute:
         return _StringAttribute()
 
     def check(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_string_attribute.py
@@ -5,28 +5,49 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import (
+    _Scope,
+)
+
 from ._attribute_abc import _Attribute
 
 
 @dataclass
 class _StringAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict | str) -> bool:
-        return data == "string"
+    def supports(cls, data: dict) -> bool:
+        return "attribute_type" in data and data["attribute_type"] == "string"
 
     @classmethod
-    def fromdict(cls, _: dict | str) -> _StringAttribute:
-        return _StringAttribute()
+    def fromdict(cls, data: dict) -> _StringAttribute:
+        if not cls.supports(data):
+            raise ValueError
+
+        return _StringAttribute(
+            optional=data.get("optional", False),
+            scope=_Scope(data["scope"]),
+            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+        )
 
     def check_type_and_value(
-        self, attribute_name: str, attribute_value: bool | float | str | list, annotation_id: str
-    ) -> list[str]:
+        self,
+        attribute_name: str,
+        attribute_value: bool | float | str | list,
+        identifiers: IssueIdentifiers,
+    ) -> list[Issue]:
         errors = []
 
         if type(attribute_value) is not str:
             errors.append(
-                f"Attribute '{attribute_name}' of annotation {annotation_id} is of type "
-                f"'{attribute_value.__class__.__name__}' (should be 'str')."
+                Issue(
+                    type=IssueType.ATTRIBUTE_TYPE,
+                    reason=(
+                        f"Attribute '{attribute_name}' is of type"
+                        f" {attribute_value.__class__.__name__} (should be 'str')."
+                    ),
+                    identifiers=identifiers,
+                )
             )
 
         return errors

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
@@ -11,15 +11,15 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _VectorAttribute(_Attribute):
     @classmethod
-    def supports(cls, data_dict: dict) -> bool:
-        return data_dict == "vector"
+    def supports(cls, data: dict | str) -> bool:
+        return data == "vector"
 
     @classmethod
-    def fromdict(cls, _: dict) -> _VectorAttribute:
+    def fromdict(cls, _: dict | str) -> _VectorAttribute:
         return _VectorAttribute()
 
     def check(
-        self, attribute_name: str, attribute_value: list | int | str | bool, annotation_id: str
+        self, attribute_name: str, attribute_value: list | float | str | bool, annotation_id: str
     ) -> list[str]:
         errors = []
 

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
@@ -5,28 +5,49 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import (
+    _Scope,
+)
+
 from ._attribute_abc import _Attribute
 
 
 @dataclass
 class _VectorAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict | str) -> bool:
-        return data == "vector"
+    def supports(cls, data: dict) -> bool:
+        return "attribute_type" in data and data["attribute_type"] == "vector"
 
     @classmethod
-    def fromdict(cls, _: dict | str) -> _VectorAttribute:
-        return _VectorAttribute()
+    def fromdict(cls, data: dict) -> _VectorAttribute:
+        if not cls.supports(data):
+            raise ValueError
+
+        return _VectorAttribute(
+            optional=data.get("optional", False),
+            scope=_Scope(data["scope"]),
+            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+        )
 
     def check_type_and_value(
-        self, attribute_name: str, attribute_value: list | float | str | bool, annotation_id: str
-    ) -> list[str]:
+        self,
+        attribute_name: str,
+        attribute_value: list | float | str | bool,
+        identifiers: IssueIdentifiers,
+    ) -> list[Issue]:
         errors = []
 
         if type(attribute_value) is not list:
             errors.append(
-                f"Attribute '{attribute_name}' of annotation {annotation_id} is of type "
-                f"'{attribute_value.__class__.__name__}' (should be 'list')."
+                Issue(
+                    type=IssueType.ATTRIBUTE_TYPE,
+                    reason=(
+                        f"Attribute '{attribute_name}' is of type"
+                        f" {attribute_value.__class__.__name__} (should be 'list')."
+                    ),
+                    identifiers=identifiers,
+                )
             )
 
         return errors

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
@@ -18,7 +18,7 @@ class _VectorAttribute(_Attribute):
     def fromdict(cls, _: dict | str) -> _VectorAttribute:
         return _VectorAttribute()
 
-    def check(
+    def check_type_and_value(
         self, attribute_name: str, attribute_value: list | float | str | bool, annotation_id: str
     ) -> list[str]:
         errors = []

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_attributes/_vector_attribute.py
@@ -16,18 +16,18 @@ from ._attribute_abc import _Attribute
 @dataclass
 class _VectorAttribute(_Attribute):
     @classmethod
-    def supports(cls, data: dict) -> bool:
-        return "attribute_type" in data and data["attribute_type"] == "vector"
+    def supports(cls, attribute_dict: dict) -> bool:
+        return "attribute_type" in attribute_dict and attribute_dict["attribute_type"] == "vector"
 
     @classmethod
-    def fromdict(cls, data: dict) -> _VectorAttribute:
-        if not cls.supports(data):
+    def fromdict(cls, attribute_dict: dict) -> _VectorAttribute:
+        if not cls.supports(attribute_dict):
             raise ValueError
 
         return _VectorAttribute(
-            optional=data.get("optional", False),
-            scope=_Scope(data["scope"]),
-            sensor_types=data.get("sensor_types", ["camera", "lidar", "radar"]),
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict["scope"]),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
         )
 
     def check_type_and_value(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
@@ -13,7 +13,7 @@ from ._sensor_type import _SensorType
 
 @dataclass
 class _ObjectClass:
-    attributes: dict[str, type[_Attribute]]
+    attributes: dict[str, _Attribute]
     sensor_types: dict[raillabel.format.SensorType, _SensorType]
 
     @classmethod
@@ -42,7 +42,7 @@ class _ObjectClass:
         return errors
 
     @classmethod
-    def _attribute_fromdict(cls, attribute: dict or str) -> type[_Attribute]:
+    def _attribute_fromdict(cls, attribute: dict | str) -> _Attribute:
         for attribute_class in attribute_classes():
             if attribute_class.supports(attribute):
                 return attribute_class.fromdict(attribute)
@@ -92,7 +92,7 @@ class _ObjectClass:
 
     def _compile_applicable_attributes(
         self, annotation: type[raillabel.format._ObjectAnnotation]
-    ) -> dict[str, type[_Attribute]]:
+    ) -> dict[str, _Attribute]:
         applicable_attributes = self.attributes
 
         if annotation.sensor.type in self.sensor_types:

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
@@ -23,10 +23,7 @@ class _ObjectClass:
     @classmethod
     def fromdict(cls, data: dict) -> _ObjectClass:
         return _ObjectClass(
-            attributes={
-                attr_name: cls._attribute_fromdict(attr)
-                for attr_name, attr in data.get("attributes", {}).items()
-            }
+            attributes={attr_name: cls._attribute_fromdict(attr) for attr_name, attr in data.items()}
         )
 
     def check(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
@@ -21,9 +21,6 @@ class _ObjectClass:
         if "attributes" not in data_dict:
             data_dict["attributes"] = {}
 
-        if "sensor_types" not in data_dict:
-            data_dict["sensor_types"] = {}
-
         return _ObjectClass(
             attributes={
                 attr_name: cls._attribute_fromdict(attr)
@@ -85,7 +82,9 @@ class _ObjectClass:
                 continue
 
             errors.extend(
-                applicable_attributes[attr_name].check(attr_name, attr_value, annotation.uid)
+                applicable_attributes[attr_name].check_type_and_value(
+                    attr_name, attr_value, annotation.uid
+                )
             )
 
         return errors
@@ -93,9 +92,8 @@ class _ObjectClass:
     def _compile_applicable_attributes(
         self, annotation: type[raillabel.format._ObjectAnnotation]
     ) -> dict[str, _Attribute]:
-        applicable_attributes = self.attributes
-
-        if annotation.sensor.type in self.sensor_types:
-            applicable_attributes.update(self.sensor_types[annotation.sensor.type].attributes)
-
-        return applicable_attributes
+        return {
+            attr_name: attr
+            for attr_name, attr in self.attributes.items()
+            if annotation.sensor.type in attr.sensor_types
+        }

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
@@ -73,9 +73,9 @@ class _ObjectClass:
         return [
             Issue(
                 type=IssueType.ATTRIBUTE_UNDEFINED,
-                reason=f"Undefined attribute '{attr_name}'",
                 identifiers=IssueIdentifiers(
                     annotation=annotation_uid,
+                    attribute=attr_name,
                     frame=frame_id,
                     object=annotation.object_id,
                     sensor=annotation.sensor_id,
@@ -99,9 +99,9 @@ class _ObjectClass:
         return [
             Issue(
                 type=IssueType.ATTRIBUTE_MISSING,
-                reason=f"Missing attribute '{attr_name}'",
                 identifiers=IssueIdentifiers(
                     annotation=annotation_uid,
+                    attribute=attr_name,
                     frame=frame_id,
                     object=annotation.object_id,
                     sensor=annotation.sensor_id,
@@ -135,6 +135,7 @@ class _ObjectClass:
                     attr_value,
                     identifiers=IssueIdentifiers(
                         annotation=annotation_uid,
+                        attribute=attr_name,
                         frame=frame_id,
                         object=annotation.object_id,
                         sensor=annotation.sensor_id,

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
@@ -4,96 +4,155 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import UUID
 
 import raillabel
 
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._sensor_type import (
+    _SensorType,
+)
+
 from ._attributes._attribute_abc import _Attribute, attribute_classes
-from ._sensor_type import _SensorType
 
 
 @dataclass
 class _ObjectClass:
     attributes: dict[str, _Attribute]
-    sensor_types: dict[raillabel.format.SensorType, _SensorType]
 
     @classmethod
-    def fromdict(cls, data_dict: dict) -> _ObjectClass:
-        if "attributes" not in data_dict:
-            data_dict["attributes"] = {}
-
+    def fromdict(cls, data: dict) -> _ObjectClass:
         return _ObjectClass(
             attributes={
                 attr_name: cls._attribute_fromdict(attr)
-                for attr_name, attr in data_dict["attributes"].items()
-            },
-            sensor_types=cls._sensor_types_fromdict(data_dict["sensor_types"]),
+                for attr_name, attr in data.get("attributes", {}).items()
+            }
         )
 
-    def check(self, annotation: type[raillabel.format._ObjectAnnotation]) -> list[str]:
+    def check(
+        self,
+        annotation_uid: UUID,
+        annotation: raillabel.format.Bbox
+        | raillabel.format.Cuboid
+        | raillabel.format.Poly2d
+        | raillabel.format.Poly3d
+        | raillabel.format.Seg3d,
+        sensor_type: _SensorType,
+        frame_id: int,
+    ) -> list[Issue]:
         errors = []
 
-        errors.extend(self._check_undefined_attributes(annotation))
-        errors.extend(self._check_missing_attributes(annotation))
-        errors.extend(self._check_false_attribute_type(annotation))
+        errors.extend(
+            self._check_undefined_attributes(annotation_uid, annotation, sensor_type, frame_id)
+        )
+        errors.extend(
+            self._check_missing_attributes(annotation_uid, annotation, sensor_type, frame_id)
+        )
+        errors.extend(
+            self._check_false_attribute_type(annotation_uid, annotation, sensor_type, frame_id)
+        )
 
         return errors
 
     @classmethod
-    def _attribute_fromdict(cls, attribute: dict | str) -> _Attribute:
+    def _attribute_fromdict(cls, attribute: dict) -> _Attribute:
         for attribute_class in attribute_classes():
             if attribute_class.supports(attribute):
                 return attribute_class.fromdict(attribute)
 
         raise ValueError
 
-    @classmethod
-    def _sensor_types_fromdict(cls, sensor_types_dict: dict) -> dict[str, _SensorType]:
-        return {
-            raillabel.format.SensorType(type_id): _SensorType.fromdict(sensor_type_dict)
-            for type_id, sensor_type_dict in sensor_types_dict.items()
-        }
-
     def _check_undefined_attributes(
-        self, annotation: type[raillabel.format._ObjectAnnotation]
-    ) -> list[str]:
+        self,
+        annotation_uid: UUID,
+        annotation: raillabel.format.Bbox
+        | raillabel.format.Cuboid
+        | raillabel.format.Poly2d
+        | raillabel.format.Poly3d
+        | raillabel.format.Seg3d,
+        sensor_type: _SensorType,
+        frame_id: int,
+    ) -> list[Issue]:
         return [
-            f"Undefined attribute '{attr_name}' in annotation {annotation.uid}."
+            Issue(
+                type=IssueType.ATTRIBUTE_UNDEFINED,
+                reason=f"Undefined attribute '{attr_name}'",
+                identifiers=IssueIdentifiers(
+                    annotation=annotation_uid,
+                    frame=frame_id,
+                    object=annotation.object_id,
+                    sensor=annotation.sensor_id,
+                ),
+            )
             for attr_name in annotation.attributes
-            if attr_name not in self._compile_applicable_attributes(annotation)
+            if attr_name not in self._compile_applicable_attributes(sensor_type)
         ]
 
     def _check_missing_attributes(
-        self, annotation: type[raillabel.format._ObjectAnnotation]
-    ) -> list[str]:
+        self,
+        annotation_uid: UUID,
+        annotation: raillabel.format.Bbox
+        | raillabel.format.Cuboid
+        | raillabel.format.Poly2d
+        | raillabel.format.Poly3d
+        | raillabel.format.Seg3d,
+        sensor_type: _SensorType,
+        frame_id: int,
+    ) -> list[Issue]:
         return [
-            f"Missing attribute '{attr_name}' in annotation {annotation.uid}."
-            for attr_name in self._compile_applicable_attributes(annotation)
+            Issue(
+                type=IssueType.ATTRIBUTE_MISSING,
+                reason=f"Missing attribute '{attr_name}'",
+                identifiers=IssueIdentifiers(
+                    annotation=annotation_uid,
+                    frame=frame_id,
+                    object=annotation.object_id,
+                    sensor=annotation.sensor_id,
+                ),
+            )
+            for attr_name in self._compile_applicable_attributes(sensor_type)
             if attr_name not in annotation.attributes
         ]
 
     def _check_false_attribute_type(
-        self, annotation: type[raillabel.format._ObjectAnnotation]
-    ) -> list[str]:
+        self,
+        annotation_uid: UUID,
+        annotation: raillabel.format.Bbox
+        | raillabel.format.Cuboid
+        | raillabel.format.Poly2d
+        | raillabel.format.Poly3d
+        | raillabel.format.Seg3d,
+        sensor_type: _SensorType,
+        frame_id: int,
+    ) -> list[Issue]:
         errors = []
 
-        applicable_attributes = self._compile_applicable_attributes(annotation)
+        applicable_attributes = self._compile_applicable_attributes(sensor_type)
         for attr_name, attr_value in annotation.attributes.items():
             if attr_name not in applicable_attributes:
                 continue
 
             errors.extend(
                 applicable_attributes[attr_name].check_type_and_value(
-                    attr_name, attr_value, annotation.uid
+                    attr_name,
+                    attr_value,
+                    identifiers=IssueIdentifiers(
+                        annotation=annotation_uid,
+                        frame=frame_id,
+                        object=annotation.object_id,
+                        sensor=annotation.sensor_id,
+                    ),
                 )
             )
 
         return errors
 
     def _compile_applicable_attributes(
-        self, annotation: type[raillabel.format._ObjectAnnotation]
+        self,
+        sensor_type: _SensorType,
     ) -> dict[str, _Attribute]:
         return {
             attr_name: attr
             for attr_name, attr in self.attributes.items()
-            if annotation.sensor.type in attr.sensor_types
+            if sensor_type in [_SensorType(sensor_type_str) for sensor_type_str in attr.sensor_types]
         }

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_object_classes.py
@@ -107,8 +107,8 @@ class _ObjectClass:
                     sensor=annotation.sensor_id,
                 ),
             )
-            for attr_name in self._compile_applicable_attributes(sensor_type)
-            if attr_name not in annotation.attributes
+            for attr_name, attr in self._compile_applicable_attributes(sensor_type).items()
+            if attr_name not in annotation.attributes and not attr.optional
         ]
 
     def _check_false_attribute_type(

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
@@ -31,7 +31,7 @@ class _Onthology:
         self.errors = []
 
         self._check_class_validity(scene)
-        annotations = self._compile_annotations(scene)
+        annotations = _Onthology._compile_annotations(scene)
         for annotation_uid, annotation, sensor_type, frame_id in annotations:
             self.errors.extend(
                 self.classes[scene.objects.get(annotation.object_id).type].check(
@@ -53,8 +53,9 @@ class _Onthology:
                     )
                 )
 
+    @classmethod
     def _compile_annotations(
-        self, scene: raillabel.Scene
+        cls, scene: raillabel.Scene
     ) -> list[
         tuple[
             UUID,

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
@@ -70,16 +70,23 @@ class _Onthology:
     ]:
         annotations = []
         for frame_id, frame in scene.frames.items():
-            annotations.extend(
-                [
+            for annotation_uid, annotation in frame.annotations.items():
+                sensor_type_str = scene.sensors.get(annotation.sensor_id).TYPE
+
+                sensor_type = None
+                try:
+                    sensor_type = _SensorType(sensor_type_str)
+                except ValueError:
+                    # NOTE: This would be detected by validate_schema
+                    continue
+
+                annotations.append(
                     (
                         annotation_uid,
                         annotation,
-                        _SensorType(scene.sensors.get(annotation.sensor_id).TYPE),
+                        sensor_type,
                         frame_id,
                     )
-                    for annotation_uid, annotation in frame.annotations.items()
-                ]
-            )
+                )
 
         return annotations

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import typing as t
 from dataclasses import dataclass
 
 import raillabel
@@ -14,7 +13,7 @@ from ._object_classes import _ObjectClass
 @dataclass
 class _Onthology:
     classes: dict[str, _ObjectClass]
-    errors: t.ClassVar = []
+    errors: list[str]
 
     @classmethod
     def fromdict(cls, data_dict: dict) -> _Onthology:
@@ -32,7 +31,7 @@ class _Onthology:
 
         return self.errors
 
-    def _check_class_validity(self, scene: raillabel.Scene) -> list[str]:
+    def _check_class_validity(self, scene: raillabel.Scene) -> None:
         object_classes_in_scene = [obj.type for obj in scene.objects.values()]
 
         for object_class in object_classes_in_scene:

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_onthology.py
@@ -24,7 +24,7 @@ class _Onthology:
     @classmethod
     def fromdict(cls, data: dict) -> _Onthology:
         return _Onthology(
-            {class_id: _ObjectClass.fromdict(class_) for class_id, class_ in data.items()}
+            {class_id: _ObjectClass.fromdict(class_) for class_id, class_ in data.items()}, []
         )
 
     def check(self, scene: raillabel.Scene) -> list[Issue]:

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_scope.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_scope.py
@@ -1,0 +1,10 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from enum import Enum
+
+
+class _Scope(Enum):
+    ANNOTATION = "annotation"
+    FRAME = "frame"
+    OBJECT = "object"

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_sensor_type.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_sensor_type.py
@@ -1,13 +1,10 @@
 # Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
-from dataclasses import dataclass
+from enum import Enum
 
 
-@dataclass
-class _SensorType:
-    @classmethod
-    def fromdict(cls) -> _SensorType:
-        return _SensorType()
+class _SensorType(Enum):
+    CAMERA = "camera"
+    LIDAR = "lidar"
+    RADAR = "radar"

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_sensor_type.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_sensor_type.py
@@ -5,29 +5,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ._attributes._attribute_abc import _Attribute, attribute_classes
-
 
 @dataclass
 class _SensorType:
-    attributes: dict[str, _Attribute]
-
     @classmethod
-    def fromdict(cls, data_dict: dict) -> _SensorType:
-        if "attributes" not in data_dict:
-            data_dict["attributes"] = {}
-
-        return _SensorType(
-            attributes={
-                attr_name: cls._attribute_fromdict(attr)
-                for attr_name, attr in data_dict["attributes"].items()
-            }
-        )
-
-    @classmethod
-    def _attribute_fromdict(cls, attribute: dict | str) -> _Attribute:
-        for attribute_class in attribute_classes():
-            if attribute_class.supports(attribute):
-                return attribute_class.fromdict(attribute)
-
-        raise ValueError
+    def fromdict(cls) -> _SensorType:
+        return _SensorType()

--- a/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_sensor_type.py
+++ b/raillabel_providerkit/validation/validate_onthology/_onthology_classes/_sensor_type.py
@@ -10,7 +10,7 @@ from ._attributes._attribute_abc import _Attribute, attribute_classes
 
 @dataclass
 class _SensorType:
-    attributes: dict[str, type[_Attribute]]
+    attributes: dict[str, _Attribute]
 
     @classmethod
     def fromdict(cls, data_dict: dict) -> _SensorType:
@@ -25,7 +25,7 @@ class _SensorType:
         )
 
     @classmethod
-    def _attribute_fromdict(cls, attribute: dict | str) -> type[_Attribute]:
+    def _attribute_fromdict(cls, attribute: dict | str) -> _Attribute:
         for attribute_class in attribute_classes():
             if attribute_class.supports(attribute):
                 return attribute_class.fromdict(attribute)

--- a/raillabel_providerkit/validation/validate_onthology/onthology_schema_v1.yaml
+++ b/raillabel_providerkit/validation/validate_onthology/onthology_schema_v1.yaml
@@ -7,6 +7,15 @@ version: 1.0.0
 definitions:
 
     attribute:
+        additionalProperties: false
+        properties:
+            attribute_type:
+                "$ref": "#/definitions/attribute_type"
+            scope:
+                enum: [annotation, frame, object]
+        type: object
+
+    attribute_type:
         oneOf:
             [
                 "$ref": "#/definitions/boolean_attribute",

--- a/raillabel_providerkit/validation/validate_onthology/onthology_schema_v2.yaml
+++ b/raillabel_providerkit/validation/validate_onthology/onthology_schema_v2.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 "$schema": http://json-schema.org/draft-07/schema#
-version: 1.0.0
+version: 2.0.0
 
 definitions:
 
@@ -11,8 +11,15 @@ definitions:
         properties:
             attribute_type:
                 "$ref": "#/definitions/attribute_type"
+            optional:
+                type: boolean
             scope:
                 enum: [annotation, frame, object]
+            sensor_types:
+                items:
+                    enum: [camera, lidar, radar]
+                type: array
+        required: [attribute_type, scope]
         type: object
 
     attribute_type:
@@ -20,6 +27,7 @@ definitions:
             [
                 "$ref": "#/definitions/boolean_attribute",
                 "$ref": "#/definitions/integer_attribute",
+                "$ref": "#/definitions/multi_reference_attribute",
                 "$ref": "#/definitions/multi_select_attribute",
                 "$ref": "#/definitions/single_select_attribute",
                 "$ref": "#/definitions/string_attribute",
@@ -30,20 +38,8 @@ definitions:
         const: boolean
 
     class:
-        additionalProperties: false
-        properties:
-            attributes:
-                additionalProperties: false
-                patternProperties:
-                    "^":
-                        "$ref": "#/definitions/attribute"
-                type: object
-            sensor_types:
-                additionalProperties: false
-                patternProperties:
-                    "^(camera|lidar|radar)$":
-                        "$ref": "#/definitions/sensor_type"
-                type: object
+        additionalProperties:
+            "$ref": "#/definitions/attribute"
         type: object
 
     integer_attribute:
@@ -60,6 +56,9 @@ definitions:
                     type: string
         type: object
 
+    multi_reference_attribute:
+        const: multi-reference
+
     multi_select_attribute:
         additionalProperties: false
         properties:
@@ -71,26 +70,13 @@ definitions:
                     type: string
         type: object
 
-    sensor_type:
-        additionalProperties: false
-        properties:
-            attributes:
-                additionalProperties: false
-                patternProperties:
-                    "^":
-                        "$ref": "#/definitions/attribute"
-                type: object
-        type: object
-
     string_attribute:
         const: string
 
     vector_attribute:
         const: vector
 
-additionalProperties: false
-patternProperties:
-    "^":
-        "$ref": "#/definitions/class"
+additionalProperties:
+    "$ref": "#/definitions/class"
 
 type: object

--- a/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
@@ -49,7 +49,7 @@ def _load_onthology(path: Path) -> dict:
 
 
 def _validate_onthology_schema(onthology: dict | None) -> None:
-    schema_path = Path(__file__).parent / "onthology_schema_v1.yaml"
+    schema_path = Path(__file__).parent / "onthology_schema_v2.yaml"
 
     with schema_path.open() as f:
         onthology_schema = yaml.safe_load(f)

--- a/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
@@ -14,14 +14,14 @@ from raillabel_providerkit.exceptions import OnthologySchemaError
 from ._onthology_classes._onthology import _Onthology
 
 
-def validate_onthology(scene: raillabel.Scene, onthology: dict | Path) -> list[str]:
+def validate_onthology(scene: raillabel.Scene, onthology_input: dict | Path) -> list[str]:
     """Validate a scene based on the classes and attributes.
 
     Parameters
     ----------
     scene : raillabel.Scene
         The scene containing the annotations.
-    onthology : dict or Path
+    onthology_input : dict or Path
         Onthology YAML-data or file containing a information about all classes and their
         attributes. The onthology must adhere to the onthology_schema. If a path is provided, the
         file is loaded as a YAML.
@@ -33,12 +33,12 @@ def validate_onthology(scene: raillabel.Scene, onthology: dict | Path) -> list[s
         errors present.
 
     """
-    if isinstance(onthology, Path):
-        onthology = _load_onthology(Path(onthology))
+    if isinstance(onthology_input, Path):
+        onthology_input = _load_onthology(Path(onthology_input))
 
-    _validate_onthology_schema(onthology)
+    _validate_onthology_schema(onthology_input)
 
-    onthology = _Onthology.fromdict(onthology)
+    onthology = _Onthology.fromdict(onthology_input)
 
     return onthology.check(scene)
 

--- a/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
@@ -10,11 +10,12 @@ import raillabel
 import yaml
 
 from raillabel_providerkit.exceptions import OnthologySchemaError
+from raillabel_providerkit.validation import Issue
 
 from ._onthology_classes._onthology import _Onthology
 
 
-def validate_onthology(scene: raillabel.Scene, onthology_input: dict | Path) -> list[str]:
+def validate_onthology(scene: raillabel.Scene, onthology_input: dict | Path) -> list[Issue]:
     """Validate a scene based on the classes and attributes.
 
     Parameters
@@ -28,7 +29,7 @@ def validate_onthology(scene: raillabel.Scene, onthology_input: dict | Path) -> 
 
     Returns
     -------
-    list[str]
+    list[Issue]
         list of all onthology errors in the scene. If an empty list is returned, then there are no
         errors present.
 

--- a/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
+++ b/raillabel_providerkit/validation/validate_onthology/validate_onthology.py
@@ -48,7 +48,7 @@ def _load_onthology(path: Path) -> dict:
         return yaml.safe_load(f)
 
 
-def _validate_onthology_schema(onthology: dict) -> None:
+def _validate_onthology_schema(onthology: dict | None) -> None:
     schema_path = Path(__file__).parent / "onthology_schema_v1.yaml"
 
     with schema_path.open() as f:

--- a/tests/__assets__/osdar23_onthology.yaml
+++ b/tests/__assets__/osdar23_onthology.yaml
@@ -1,0 +1,14 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+catenary_pole:
+    attributes:
+        foo:
+            attribute_type: string
+            scope: annotation
+    sensor_types:
+        camera:
+            attributes:
+                irrelevant:
+                    attribute_type: string
+                    scope: annotation

--- a/tests/__assets__/osdar23_onthology.yaml
+++ b/tests/__assets__/osdar23_onthology.yaml
@@ -1,14 +1,684 @@
 # Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
+person:
+    function:
+        attribute_type:
+            type: single-select
+            options: [
+                passenger,
+                worker,
+                securityStaff,
+                otherStaff,
+                uniformedPerson,
+                unknown,
+                other
+            ]
+        scope: frame
+    isDummy:
+        attribute_type: boolean
+        scope: object
+    age:
+        attribute_type:
+            type: single-select
+            options: [adult, child]
+        scope: object
+    aid:
+        attribute_type:
+            type: single-select
+            options: [
+                none,
+                whiteCane,
+                walkingAid,
+                other
+            ]
+        scope: frame
+    isDistracted:
+        attribute_type: boolean
+        scope: frame
+    carrying:
+        attribute_type:
+            type: multi-select
+            options: [
+                none,
+                suitcase,
+                backpack,
+                umbrella,
+                baby,
+                other
+            ]
+        optional: true
+        scope: frame
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    pose:
+        attribute_type:
+            type: single-select
+            options: [
+                upright,
+                sitting,
+                lying,
+                other
+            ]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+crowd:
+    size:
+        attribute_type:
+            type: single-select
+            options: [
+                <25,
+                25-50,
+                50-75,
+                ">75"
+            ]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+train:
+    type:
+        attribute_type:
+            type: single-select
+            options: [
+                locomotive,
+                intercity,
+                regional,
+                commuter,
+                construction,
+                other
+            ]
+        scope: object
+    isTruncatedFront:
+        attribute_type: boolean
+        scope: annotation
+    isTruncatedBack:
+        attribute_type: boolean
+        scope: annotation
+    isFront:
+        attribute_type: boolean
+        scope: object
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+wagons:
+    type:
+        attribute_type:
+            type: single-select
+            options: [
+                intercity,
+                regional,
+                freight,
+                construction,
+                other
+            ]
+        scope: object
+    isTruncatedFront:
+        attribute_type: boolean
+        scope: annotation
+    isTruncatedBack:
+        attribute_type: boolean
+        scope: annotation
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+bicycle:
+    state:
+        attribute_type:
+            type: single-select
+            options: [
+                pushed,
+                ridden,
+                carried,
+                steady
+            ]
+        scope: frame
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+group_of_bicycles:
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+motorcycle:
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+road_vehicle:
+    type:
+        attribute_type:
+            type: single-select
+            options: [
+                car,
+                van,
+                truck,
+                bus,
+                constructionVehicle,
+                trailer,
+                other
+            ]
+        scope: object
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+animal:
+    size:
+        attribute_type:
+            type: single-select
+            options: [
+                small,
+                medium,
+                large
+            ]
+        scope: object
+    species:
+        attribute_type:
+            type: single-select
+            options: [
+                dog,
+                deer,
+                fox,
+                rabbit,
+                wildBoar,
+                cow,
+                otherAnimal
+            ]
+        scope: object
+    pose:
+        attribute_type:
+            type: single-select
+            options: [
+                upright,
+                sitting,
+                lying,
+                other
+            ]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+group_of_animals:
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+wheelchair:
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+drag_shoe:
+    onTrack:
+        attribute_type:
+            type: single-select
+            options: [
+                "-2",
+                "-1",
+                "0",
+                "+1",
+                "1",
+                "+2",
+                "2",
+                other,
+                none
+            ]
+        scope: frame
+    railSide:
+        attribute_type:
+            type: single-select
+            options: [
+                leftRail,
+                rightRail,
+                none
+            ]
+        scope: object
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+track:
+    trackID:
+        attribute_type:
+            type: single-select
+            options: [
+                "-2",
+                "-1",
+                "0",
+                "+1",
+                "1",
+                "+2",
+                "2"
+            ]
+        scope: frame
+    railSide:
+        attribute_type:
+            type: single-select
+            options: [
+                leftRail,
+                rightRail
+            ]
+        scope: object
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+transition:
+    railSide:
+        attribute_type:
+            type: single-select
+            options: [
+                leftRail,
+                rightRail
+            ]
+        scope: object
+    startTrack:
+        attribute_type:
+            type: single-select
+            options: [
+                "-2",
+                "-1",
+                "0",
+                "+1",
+                "1",
+                "+2",
+                "2"
+            ]
+        scope: frame
+    endTrack:
+        attribute_type:
+            type: single-select
+            options: [
+                "-2",
+                "-1",
+                "0",
+                "+1",
+                "1",
+                "+2",
+                "2"
+            ]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+switch:
+    onTrack:
+        attribute_type:
+            type: single-select
+            options: [
+                "-2",
+                "-1",
+                "0",
+                "+1",
+                "1",
+                "+2",
+                "2"
+            ]
+        scope: frame
+    state:
+        attribute_type:
+            type: single-select
+            options: [
+                left,
+                center,
+                right,
+                unknown
+            ]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
 catenary_pole:
-    attributes:
-        foo:
-            attribute_type: string
-            scope: annotation
-    sensor_types:
-        camera:
-            attributes:
-                irrelevant:
-                    attribute_type: string
-                    scope: annotation
+    type:
+        attribute_type:
+            type: single-select
+            options: [solid, structured]
+        scope: object
+    isTruncatedTop:
+        attribute_type: boolean
+        scope: annotation
+    isTruncatedBottom:
+        attribute_type: boolean
+        scope: annotation
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+signal_pole:
+    type:
+        attribute_type:
+            type: single-select
+            options: [solid, structured]
+        scope: object
+    isTruncatedTop:
+        attribute_type: boolean
+        scope: annotation
+    isTruncatedBottom:
+        attribute_type: boolean
+        scope: annotation
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+signal:
+    type:
+        attribute_type:
+            type: single-select
+            options: [light, shape]
+        scope: object
+    signalFace:
+        attribute_type:
+            type: single-select
+            options: [
+                front,
+                back,
+                unknown
+            ]
+        scope: frame
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+signal_bridge:
+    type:
+        attribute_type:
+            type: single-select
+            options: [solid, structured]
+        scope: object
+    isTruncatedLeft:
+        attribute_type: boolean
+        scope: annotation
+    isTruncatedRight:
+        attribute_type: boolean
+        scope: annotation
+    connectedTo:
+        attribute_type: multi-reference
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+buffer_stop:
+    onTrack:
+        attribute_type:
+            type: single-select
+            options: [
+                "-2",
+                "-1",
+                "0",
+                "+1",
+                "1",
+                "+2",
+                "2",
+                other,
+                none
+            ]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+flame:
+    size:
+        attribute_type:
+            type: single-select
+            options: [big, small]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation
+
+smoke:
+    size:
+        attribute_type:
+            type: single-select
+            options: [big, small]
+        scope: frame
+    color:
+        attribute_type:
+            type: single-select
+            options: [
+                white,
+                gray,
+                black,
+                other
+            ]
+        scope: frame
+    occlusion:
+        attribute_type:
+            type: single-select
+            options: [
+                0-25 %,
+                25-50 %,
+                50-75 %,
+                75-99 %,
+                100 %,
+                undefined
+            ]
+        scope: annotation

--- a/tests/validation/validate_onthology/conftest.py
+++ b/tests/validation/validate_onthology/conftest.py
@@ -1,0 +1,45 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+@pytest.fixture
+def example_boolean_attribute_dict():
+    return {"attribute_type": "boolean", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_integer_attribute_dict():
+    return {"attribute_type": "integer", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_multi_reference_attribute_dict():
+    return {"attribute_type": "multi-reference", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_multi_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "multi-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_vector_attribute_dict():
+    return {"attribute_type": "vector", "scope": "annotation"}

--- a/tests/validation/validate_onthology/test_boolean_attribute.py
+++ b/tests/validation/validate_onthology/test_boolean_attribute.py
@@ -10,24 +10,6 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
-@pytest.fixture
-def example_boolean_attribute_dict():
-    return {"attribute_type": "boolean", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_string_attribute_dict():
-    return {"attribute_type": "string", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_single_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
 def test_supports__empty_dict():
     assert not _BooleanAttribute.supports({})
 

--- a/tests/validation/validate_onthology/test_boolean_attribute.py
+++ b/tests/validation/validate_onthology/test_boolean_attribute.py
@@ -1,0 +1,88 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._boolean_attribute import (
+    _BooleanAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+@pytest.fixture
+def example_boolean_attribute_dict():
+    return {"attribute_type": "boolean", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+def test_supports__empty_dict():
+    assert not _BooleanAttribute.supports({})
+
+
+def test_supports__correct(example_boolean_attribute_dict):
+    assert _BooleanAttribute.supports(example_boolean_attribute_dict)
+
+
+def test_supports__invalid_type_string(example_string_attribute_dict):
+    assert not _BooleanAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_single_select_attribute_dict):
+    assert not _BooleanAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _BooleanAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_boolean_attribute_dict):
+    for val in [False, True]:
+        example_boolean_attribute_dict["optional"] = val
+        assert _BooleanAttribute.fromdict(example_boolean_attribute_dict).optional == val
+
+
+def test_fromdict__scope_invalid(example_boolean_attribute_dict):
+    with pytest.raises(ValueError):
+        example_boolean_attribute_dict["scope"] = "some random string"
+        _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+
+
+def test_fromdict__scope_annotation(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["scope"] = "annotation"
+    assert _BooleanAttribute.fromdict(example_boolean_attribute_dict).scope == _Scope.ANNOTATION
+
+
+def test_fromdict__scope_frame(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["scope"] = "frame"
+    assert _BooleanAttribute.fromdict(example_boolean_attribute_dict).scope == _Scope.FRAME
+
+
+def test_fromdict__scope_object(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["scope"] = "object"
+    assert _BooleanAttribute.fromdict(example_boolean_attribute_dict).scope == _Scope.OBJECT
+
+
+def test_check_type_and_value__wrong_type(example_boolean_attribute_dict):
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    errors = attr.check_type_and_value("example_name", 42, IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_type_and_value__correct(example_boolean_attribute_dict):
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    assert attr.check_type_and_value("example_name", True, IssueIdentifiers()) == []

--- a/tests/validation/validate_onthology/test_integer_attribute.py
+++ b/tests/validation/validate_onthology/test_integer_attribute.py
@@ -1,0 +1,88 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._integer_attribute import (
+    _IntegerAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+@pytest.fixture
+def example_integer_attribute_dict():
+    return {"attribute_type": "integer", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+def test_supports__empty_dict():
+    assert not _IntegerAttribute.supports({})
+
+
+def test_supports__correct(example_integer_attribute_dict):
+    assert _IntegerAttribute.supports(example_integer_attribute_dict)
+
+
+def test_supports__invalid_type_string(example_string_attribute_dict):
+    assert not _IntegerAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_single_select_attribute_dict):
+    assert not _IntegerAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _IntegerAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_integer_attribute_dict):
+    for val in [False, True]:
+        example_integer_attribute_dict["optional"] = val
+        assert _IntegerAttribute.fromdict(example_integer_attribute_dict).optional == val
+
+
+def test_fromdict__scope_invalid(example_integer_attribute_dict):
+    with pytest.raises(ValueError):
+        example_integer_attribute_dict["scope"] = "some random string"
+        _IntegerAttribute.fromdict(example_integer_attribute_dict)
+
+
+def test_fromdict__scope_annotation(example_integer_attribute_dict):
+    example_integer_attribute_dict["scope"] = "annotation"
+    assert _IntegerAttribute.fromdict(example_integer_attribute_dict).scope == _Scope.ANNOTATION
+
+
+def test_fromdict__scope_frame(example_integer_attribute_dict):
+    example_integer_attribute_dict["scope"] = "frame"
+    assert _IntegerAttribute.fromdict(example_integer_attribute_dict).scope == _Scope.FRAME
+
+
+def test_fromdict__scope_object(example_integer_attribute_dict):
+    example_integer_attribute_dict["scope"] = "object"
+    assert _IntegerAttribute.fromdict(example_integer_attribute_dict).scope == _Scope.OBJECT
+
+
+def test_check_type_and_value__wrong_type(example_integer_attribute_dict):
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    errors = attr.check_type_and_value("example_name", "not an integer", IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_type_and_value__correct(example_integer_attribute_dict):
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    assert attr.check_type_and_value("example_name", 42, IssueIdentifiers()) == []

--- a/tests/validation/validate_onthology/test_integer_attribute.py
+++ b/tests/validation/validate_onthology/test_integer_attribute.py
@@ -10,24 +10,6 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
-@pytest.fixture
-def example_integer_attribute_dict():
-    return {"attribute_type": "integer", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_string_attribute_dict():
-    return {"attribute_type": "string", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_single_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
 def test_supports__empty_dict():
     assert not _IntegerAttribute.supports({})
 

--- a/tests/validation/validate_onthology/test_multi_reference_attribute.py
+++ b/tests/validation/validate_onthology/test_multi_reference_attribute.py
@@ -10,24 +10,6 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
-@pytest.fixture
-def example_multi_reference_attribute_dict():
-    return {"attribute_type": "multi-reference", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_string_attribute_dict():
-    return {"attribute_type": "string", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_single_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
 def test_supports__empty_dict():
     assert not _MultiReferenceAttribute.supports({})
 

--- a/tests/validation/validate_onthology/test_multi_reference_attribute.py
+++ b/tests/validation/validate_onthology/test_multi_reference_attribute.py
@@ -1,0 +1,113 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._multi_reference_attribute import (
+    _MultiReferenceAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+@pytest.fixture
+def example_multi_reference_attribute_dict():
+    return {"attribute_type": "multi-reference", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+def test_supports__empty_dict():
+    assert not _MultiReferenceAttribute.supports({})
+
+
+def test_supports__correct(example_multi_reference_attribute_dict):
+    assert _MultiReferenceAttribute.supports(example_multi_reference_attribute_dict)
+
+
+def test_supports__invalid_type_string(example_string_attribute_dict):
+    assert not _MultiReferenceAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_single_select_attribute_dict):
+    assert not _MultiReferenceAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _MultiReferenceAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_multi_reference_attribute_dict):
+    for val in [False, True]:
+        example_multi_reference_attribute_dict["optional"] = val
+        assert (
+            _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict).optional == val
+        )
+
+
+def test_fromdict__scope_invalid(example_multi_reference_attribute_dict):
+    with pytest.raises(ValueError):
+        example_multi_reference_attribute_dict["scope"] = "some random string"
+        _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+
+
+def test_fromdict__scope_annotation(example_multi_reference_attribute_dict):
+    example_multi_reference_attribute_dict["scope"] = "annotation"
+    assert (
+        _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict).scope
+        == _Scope.ANNOTATION
+    )
+
+
+def test_fromdict__scope_frame(example_multi_reference_attribute_dict):
+    example_multi_reference_attribute_dict["scope"] = "frame"
+    assert (
+        _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict).scope
+        == _Scope.FRAME
+    )
+
+
+def test_fromdict__scope_object(example_multi_reference_attribute_dict):
+    example_multi_reference_attribute_dict["scope"] = "object"
+    assert (
+        _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict).scope
+        == _Scope.OBJECT
+    )
+
+
+def test_check_type_and_value__wrong_type(example_multi_reference_attribute_dict):
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    errors = attr.check_type_and_value("example_name", 42, IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_type_and_value__wrong_value(example_multi_reference_attribute_dict):
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    errors = attr.check_type_and_value("example_name", ["some non-uuid string"], IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_VALUE
+
+
+def test_check_type_and_value__correct(example_multi_reference_attribute_dict):
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_type_and_value(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e", "fcc35567-7559-421e-acdc-89287e5a8c9c"],
+            IssueIdentifiers(),
+        )
+        == []
+    )

--- a/tests/validation/validate_onthology/test_multi_select_attribute.py
+++ b/tests/validation/validate_onthology/test_multi_select_attribute.py
@@ -10,27 +10,6 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
-@pytest.fixture
-def example_string_attribute_dict():
-    return {"attribute_type": "string", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_multi_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "multi-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
-@pytest.fixture
-def example_single_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
 def test_supports__empty_dict():
     assert not _MultiSelectAttribute.supports({})
 

--- a/tests/validation/validate_onthology/test_multi_select_attribute.py
+++ b/tests/validation/validate_onthology/test_multi_select_attribute.py
@@ -1,0 +1,101 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._multi_select_attribute import (
+    _MultiSelectAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_multi_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "multi-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+def test_supports__empty_dict():
+    assert not _MultiSelectAttribute.supports({})
+
+
+def test_supports__correct(example_multi_select_attribute_dict):
+    assert _MultiSelectAttribute.supports(example_multi_select_attribute_dict)
+
+
+def test_supports__invalid_type_string(example_string_attribute_dict):
+    assert not _MultiSelectAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_single_select_attribute_dict):
+    assert not _MultiSelectAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _MultiSelectAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_multi_select_attribute_dict):
+    for val in [False, True]:
+        example_multi_select_attribute_dict["optional"] = val
+        assert _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict).optional == val
+
+
+def test_fromdict__scope_invalid(example_multi_select_attribute_dict):
+    with pytest.raises(ValueError):
+        example_multi_select_attribute_dict["scope"] = "some random string"
+        _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict)
+
+
+def test_fromdict__scope_annotation(example_multi_select_attribute_dict):
+    example_multi_select_attribute_dict["scope"] = "annotation"
+    assert (
+        _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict).scope
+        == _Scope.ANNOTATION
+    )
+
+
+def test_fromdict__scope_frame(example_multi_select_attribute_dict):
+    example_multi_select_attribute_dict["scope"] = "frame"
+    assert _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict).scope == _Scope.FRAME
+
+
+def test_fromdict__scope_object(example_multi_select_attribute_dict):
+    example_multi_select_attribute_dict["scope"] = "object"
+    assert _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict).scope == _Scope.OBJECT
+
+
+def test_check_type_and_value__wrong_type(example_multi_select_attribute_dict):
+    attr = _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict)
+    errors = attr.check_type_and_value("example_name", 42, IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_type_and_value__wrong_value(example_multi_select_attribute_dict):
+    attr = _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict)
+    errors = attr.check_type_and_value("example_name", ["some invalid string"], IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_VALUE
+
+
+def test_check_type_and_value__correct(example_multi_select_attribute_dict):
+    attr = _MultiSelectAttribute.fromdict(example_multi_select_attribute_dict)
+    assert attr.check_type_and_value("example_name", ["foo"], IssueIdentifiers()) == []

--- a/tests/validation/validate_onthology/test_object_classes.py
+++ b/tests/validation/validate_onthology/test_object_classes.py
@@ -19,14 +19,9 @@ def test_fromdict__empty():
     assert len(object_class.attributes) == 0
 
 
-def test_fromdict__no_attributes():
-    object_class = _ObjectClass.fromdict({"attributes": {}})
-    assert len(object_class.attributes) == 0
-
-
 def test_fromdict__simple():
     object_class = _ObjectClass.fromdict(
-        {"attributes": {"isSomething": {"attribute_type": "boolean", "scope": "annotation"}}}
+        {"isSomething": {"attribute_type": "boolean", "scope": "annotation"}}
     )
     assert len(object_class.attributes) == 1
     assert "isSomething" in object_class.attributes

--- a/tests/validation/validate_onthology/test_object_classes.py
+++ b/tests/validation/validate_onthology/test_object_classes.py
@@ -6,12 +6,28 @@ import pytest
 from raillabel_providerkit.validation.validate_onthology._onthology_classes._object_classes import (
     _ObjectClass,
 )
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._boolean_attribute import (
+    _BooleanAttribute,
+)
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._integer_attribute import (
+    _IntegerAttribute,
+)
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._multi_reference_attribute import (
+    _MultiReferenceAttribute,
+)
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._multi_select_attribute import (
+    _MultiSelectAttribute,
+)
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._single_select_attribute import (
+    _SingleSelectAttribute,
+)
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._string_attribute import (
+    _StringAttribute,
+)
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._vector_attribute import (
+    _VectorAttribute,
+)
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
-
-
-# @pytest.fixture
-# def simple_object_class_dict() -> dict:
-#     return
 
 
 def test_fromdict__empty():
@@ -19,9 +35,54 @@ def test_fromdict__empty():
     assert len(object_class.attributes) == 0
 
 
-def test_fromdict__simple():
-    object_class = _ObjectClass.fromdict(
-        {"isSomething": {"attribute_type": "boolean", "scope": "annotation"}}
-    )
+def test_fromdict__simple(example_boolean_attribute_dict):
+    object_class = _ObjectClass.fromdict({"isSomething": example_boolean_attribute_dict})
     assert len(object_class.attributes) == 1
     assert "isSomething" in object_class.attributes
+
+
+def test_attribute_fromdict__empty():
+    with pytest.raises(ValueError):
+        _ObjectClass._attribute_fromdict({})
+
+
+def test_attribute_fromdict__invalid_attribute_type():
+    with pytest.raises(ValueError):
+        _ObjectClass._attribute_fromdict(
+            {"attribute_type": "some-invalid-attribute-type", "scope": "annotation"}
+        )
+
+
+def test_attribute_fromdict__boolean(example_boolean_attribute_dict):
+    result = _ObjectClass._attribute_fromdict(example_boolean_attribute_dict)
+    assert isinstance(result, _BooleanAttribute)
+
+
+def test_attribute_fromdict__integer(example_integer_attribute_dict):
+    result = _ObjectClass._attribute_fromdict(example_integer_attribute_dict)
+    assert isinstance(result, _IntegerAttribute)
+
+
+def test_attribute_fromdict__multi_reference(example_multi_reference_attribute_dict):
+    result = _ObjectClass._attribute_fromdict(example_multi_reference_attribute_dict)
+    assert isinstance(result, _MultiReferenceAttribute)
+
+
+def test_attribute_fromdict__multi_select(example_multi_select_attribute_dict):
+    result = _ObjectClass._attribute_fromdict(example_multi_select_attribute_dict)
+    assert isinstance(result, _MultiSelectAttribute)
+
+
+def test_attribute_fromdict__single_select(example_single_select_attribute_dict):
+    result = _ObjectClass._attribute_fromdict(example_single_select_attribute_dict)
+    assert isinstance(result, _SingleSelectAttribute)
+
+
+def test_attribute_fromdict__string(example_string_attribute_dict):
+    result = _ObjectClass._attribute_fromdict(example_string_attribute_dict)
+    assert isinstance(result, _StringAttribute)
+
+
+def test_attribute_fromdict__vector(example_vector_attribute_dict):
+    result = _ObjectClass._attribute_fromdict(example_vector_attribute_dict)
+    assert isinstance(result, _VectorAttribute)

--- a/tests/validation/validate_onthology/test_object_classes.py
+++ b/tests/validation/validate_onthology/test_object_classes.py
@@ -1,0 +1,32 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._object_classes import (
+    _ObjectClass,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+# @pytest.fixture
+# def simple_object_class_dict() -> dict:
+#     return
+
+
+def test_fromdict__empty():
+    object_class = _ObjectClass.fromdict({})
+    assert len(object_class.attributes) == 0
+
+
+def test_fromdict__no_attributes():
+    object_class = _ObjectClass.fromdict({"attributes": {}})
+    assert len(object_class.attributes) == 0
+
+
+def test_fromdict__simple():
+    object_class = _ObjectClass.fromdict(
+        {"attributes": {"isSomething": {"attribute_type": "boolean", "scope": "annotation"}}}
+    )
+    assert len(object_class.attributes) == 1
+    assert "isSomething" in object_class.attributes

--- a/tests/validation/validate_onthology/test_object_classes.py
+++ b/tests/validation/validate_onthology/test_object_classes.py
@@ -27,7 +27,11 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._vector_attribute import (
     _VectorAttribute,
 )
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._sensor_type import (
+    _SensorType,
+)
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+from raillabel.format import Bbox, Point2d, Size2d
 
 
 def test_fromdict__empty():
@@ -39,6 +43,41 @@ def test_fromdict__simple(example_boolean_attribute_dict):
     object_class = _ObjectClass.fromdict({"isSomething": example_boolean_attribute_dict})
     assert len(object_class.attributes) == 1
     assert "isSomething" in object_class.attributes
+
+
+def test_check__correct(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict({"test_attribute": example_boolean_attribute_dict})
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute": True},
+    )
+    issues = object_class.check(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert issues == []
+
+
+def test_check__all_error_types(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict(
+        {
+            "test_attribute_1": example_boolean_attribute_dict,
+            "test_attribute_2": example_boolean_attribute_dict,
+        }
+    )
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute_1": "not-a-boolean", "unknown-attribute": False},
+    )
+    issues = object_class.check(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert len(issues) == 3
+    issue_types_found = [issue.type for issue in issues]
+    assert IssueType.ATTRIBUTE_UNDEFINED in issue_types_found
+    assert IssueType.ATTRIBUTE_MISSING in issue_types_found
+    assert IssueType.ATTRIBUTE_TYPE in issue_types_found
 
 
 def test_attribute_fromdict__empty():
@@ -86,3 +125,107 @@ def test_attribute_fromdict__string(example_string_attribute_dict):
 def test_attribute_fromdict__vector(example_vector_attribute_dict):
     result = _ObjectClass._attribute_fromdict(example_vector_attribute_dict)
     assert isinstance(result, _VectorAttribute)
+
+
+def test_check_undefined_attributes__correct(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict({"test_attribute": example_boolean_attribute_dict})
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute": True},
+    )
+    issues = object_class._check_undefined_attributes(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert issues == []
+
+
+def test_check_undefined_attributes__two_undefined(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict({"test_attribute": example_boolean_attribute_dict})
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute": True, "color": "yellow", "is_a_banana": False},
+    )
+    issues = object_class._check_undefined_attributes(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert len(issues) == 2
+    for issue in issues:
+        assert issue.type == IssueType.ATTRIBUTE_UNDEFINED
+
+
+def test_check_missing_attributes__correct(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict(
+        {
+            "test_attribute_1": example_boolean_attribute_dict,
+            "test_attribute_2": example_boolean_attribute_dict,
+        }
+    )
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute_1": True, "test_attribute_2": True},
+    )
+    issues = object_class._check_missing_attributes(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert issues == []
+
+
+def test_check_missing_attributes__one_missing(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict(
+        {
+            "test_attribute_1": example_boolean_attribute_dict,
+            "test_attribute_2": example_boolean_attribute_dict,
+        }
+    )
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute_2": True},
+    )
+    issues = object_class._check_missing_attributes(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert len(issues) == 1
+    assert issues[0].type == IssueType.ATTRIBUTE_MISSING
+
+
+def test_check_false_attribute_type__correct(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict({"test_attribute": example_boolean_attribute_dict})
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute": True},
+    )
+    issues = object_class._check_false_attribute_type(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert issues == []
+
+
+def test_check_false_attribute_type__incorrect(example_boolean_attribute_dict, ignore_uuid):
+    object_class = _ObjectClass.fromdict({"test_attribute": example_boolean_attribute_dict})
+    annotation = Bbox(
+        pos=Point2d(0, 0),
+        size=Size2d(1, 1),
+        object_id=ignore_uuid,
+        sensor_id="some_sensor_id",
+        attributes={"test_attribute": "i-like-trains"},
+    )
+    issues = object_class._check_false_attribute_type(ignore_uuid, annotation, _SensorType.CAMERA, 0)
+    assert len(issues) == 1
+    assert issues[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_compile_applicable_attributes__not_matching(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["sensor_types"] = ["camera"]
+    object_class = _ObjectClass.fromdict({"test_attribute": example_boolean_attribute_dict})
+    assert object_class._compile_applicable_attributes(_SensorType.LIDAR) == {}
+
+
+def test_compile_applicable_attributes__matching(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["sensor_types"] = ["camera"]
+    object_class = _ObjectClass.fromdict({"test_attribute": example_boolean_attribute_dict})
+    assert "test_attribute" in object_class._compile_applicable_attributes(_SensorType.CAMERA)

--- a/tests/validation/validate_onthology/test_object_classes.py
+++ b/tests/validation/validate_onthology/test_object_classes.py
@@ -30,7 +30,7 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation.validate_onthology._onthology_classes._sensor_type import (
     _SensorType,
 )
-from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+from raillabel_providerkit.validation import IssueType
 from raillabel.format import Bbox, Point2d, Size2d
 
 

--- a/tests/validation/validate_onthology/test_onthology.py
+++ b/tests/validation/validate_onthology/test_onthology.py
@@ -1,0 +1,205 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from uuid import UUID
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._onthology import (
+    _Onthology,
+)
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._sensor_type import (
+    _SensorType,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+from raillabel.format import Bbox, Point2d, Size2d
+from raillabel.scene_builder import SceneBuilder
+
+
+def test_fromdict__empty():
+    onthology = _Onthology.fromdict({})
+    assert len(onthology.classes) == 0
+    assert len(onthology.errors) == 0
+
+
+def test_fromdict__simple():
+    onthology = _Onthology.fromdict(
+        {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "annotation"}}}
+    )
+    assert len(onthology.classes) == 1
+    assert "banana" in onthology.classes
+    assert len(onthology.errors) == 0
+
+
+def test_check__empty_scene():
+    onthology = _Onthology.fromdict({})
+    scene = SceneBuilder.empty().result
+    issues = onthology.check(scene)
+    assert len(issues) == 0
+    assert issues == onthology.errors
+
+
+def test_check__correct():
+    onthology = _Onthology.fromdict(
+        {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "annotation"}}}
+    )
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="banana",
+            object_name="banana_0001",
+        )
+        .add_bbox(
+            UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=0,
+            object_name="banana_0001",
+            sensor_id="rgb_center",
+            attributes={"is_peelable": True},
+        )
+        .result
+    )
+    issues = onthology.check(scene)
+    assert len(issues) == 0
+    assert issues == onthology.errors
+
+
+def test_check__undefined_object_type():
+    onthology = _Onthology.fromdict(
+        {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "annotation"}}}
+    )
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="apple",
+            object_name="apple_0001",
+        )
+        .add_bbox(
+            UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=0,
+            object_name="banana_0001",
+            sensor_id="rgb_center",
+            attributes={"is_peelable": True},
+        )
+        .result
+    )
+    issues = onthology.check(scene)
+    assert len(issues) == 1
+    assert issues == onthology.errors
+    assert issues[0].type == IssueType.OBJECT_TYPE_UNDEFINED
+
+
+def test_check__invalid_attribute_type():
+    onthology = _Onthology.fromdict(
+        {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "annotation"}}}
+    )
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="banana",
+            object_name="banana_0001",
+        )
+        .add_bbox(
+            UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=0,
+            object_name="banana_0001",
+            sensor_id="rgb_center",
+            attributes={"is_peelable": "i-like-trains"},
+        )
+        .result
+    )
+    issues = onthology.check(scene)
+    assert len(issues) == 1
+    assert issues == onthology.errors
+    assert issues[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_class_validity__empty_scene():
+    onthology = _Onthology.fromdict({})
+    scene = SceneBuilder.empty().result
+    onthology._check_class_validity(scene)
+    assert len(onthology.errors) == 0
+
+
+def test_check_class_validity__correct():
+    onthology = _Onthology.fromdict(
+        {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "annotation"}}}
+    )
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="banana",
+            object_name="banana_0001",
+        )
+        .result
+    )
+    onthology._check_class_validity(scene)
+    assert len(onthology.errors) == 0
+
+
+def test_check_class_validity__incorrect():
+    onthology = _Onthology.fromdict(
+        {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "annotation"}}}
+    )
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="apple",
+            object_name="apple_0001",
+        )
+        .result
+    )
+    onthology._check_class_validity(scene)
+    assert len(onthology.errors) == 1
+    assert onthology.errors[0].type == IssueType.OBJECT_TYPE_UNDEFINED
+
+
+def test_compile_annotations__empty_scene():
+    scene = SceneBuilder.empty().result
+    annotations = _Onthology._compile_annotations(scene)
+    assert len(annotations) == 0
+
+
+def test_compile_annotations__three_annotations_in_two_frames():
+    scene = (
+        SceneBuilder.empty()
+        .add_bbox(
+            UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=0,
+            object_name="box_0001",
+            sensor_id="rgb_center",
+            attributes={},
+        )
+        .add_bbox(
+            UUID("157ae432-95b0-4e7d-86c5-414c3308e171"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=0,
+            object_name="box_0002",
+            sensor_id="rgb_center",
+            attributes={},
+        )
+        .add_bbox(
+            UUID("711cf3f3-fb2b-4f64-a785-c94bbda9b8c5"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=1,
+            object_name="box_0003",
+            sensor_id="rgb_center",
+            attributes={},
+        )
+        .result
+    )
+    annotations = _Onthology._compile_annotations(scene)
+    assert len(annotations) == 3

--- a/tests/validation/validate_onthology/test_onthology.py
+++ b/tests/validation/validate_onthology/test_onthology.py
@@ -1,17 +1,13 @@
 # Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 from uuid import UUID
 
 from raillabel_providerkit.validation.validate_onthology._onthology_classes._onthology import (
     _Onthology,
 )
-from raillabel_providerkit.validation.validate_onthology._onthology_classes._sensor_type import (
-    _SensorType,
-)
-from raillabel_providerkit.validation import IssueIdentifiers, IssueType
-from raillabel.format import Bbox, Point2d, Size2d
+from raillabel_providerkit.validation import IssueType
+from raillabel.format import Point2d, Size2d
 from raillabel.scene_builder import SceneBuilder
 
 

--- a/tests/validation/validate_onthology/test_single_select_attribute.py
+++ b/tests/validation/validate_onthology/test_single_select_attribute.py
@@ -10,27 +10,6 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
-@pytest.fixture
-def example_string_attribute_dict():
-    return {"attribute_type": "string", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_single_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
-@pytest.fixture
-def example_multi_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "multi-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
 def test_supports__empty_dict():
     assert not _SingleSelectAttribute.supports({})
 

--- a/tests/validation/validate_onthology/test_single_select_attribute.py
+++ b/tests/validation/validate_onthology/test_single_select_attribute.py
@@ -1,0 +1,105 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._single_select_attribute import (
+    _SingleSelectAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+@pytest.fixture
+def example_multi_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "multi-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+def test_supports__empty_dict():
+    assert not _SingleSelectAttribute.supports({})
+
+
+def test_supports__correct(example_single_select_attribute_dict):
+    assert _SingleSelectAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_supports__invalid_type_string(example_string_attribute_dict):
+    assert not _SingleSelectAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_multi_select_attribute_dict):
+    assert not _SingleSelectAttribute.supports(example_multi_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _SingleSelectAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_single_select_attribute_dict):
+    for val in [False, True]:
+        example_single_select_attribute_dict["optional"] = val
+        assert _SingleSelectAttribute.fromdict(example_single_select_attribute_dict).optional == val
+
+
+def test_fromdict__scope_invalid(example_single_select_attribute_dict):
+    with pytest.raises(ValueError):
+        example_single_select_attribute_dict["scope"] = "some random string"
+        _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+
+
+def test_fromdict__scope_annotation(example_single_select_attribute_dict):
+    example_single_select_attribute_dict["scope"] = "annotation"
+    assert (
+        _SingleSelectAttribute.fromdict(example_single_select_attribute_dict).scope
+        == _Scope.ANNOTATION
+    )
+
+
+def test_fromdict__scope_frame(example_single_select_attribute_dict):
+    example_single_select_attribute_dict["scope"] = "frame"
+    assert (
+        _SingleSelectAttribute.fromdict(example_single_select_attribute_dict).scope == _Scope.FRAME
+    )
+
+
+def test_fromdict__scope_object(example_single_select_attribute_dict):
+    example_single_select_attribute_dict["scope"] = "object"
+    assert (
+        _SingleSelectAttribute.fromdict(example_single_select_attribute_dict).scope == _Scope.OBJECT
+    )
+
+
+def test_check_type_and_value__wrong_type(example_single_select_attribute_dict):
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    errors = attr.check_type_and_value("example_name", 42, IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_type_and_value__wrong_value(example_single_select_attribute_dict):
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    errors = attr.check_type_and_value("example_name", "some invalid string", IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_VALUE
+
+
+def test_check_type_and_value__correct(example_single_select_attribute_dict):
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    assert attr.check_type_and_value("example_name", "foo", IssueIdentifiers()) == []

--- a/tests/validation/validate_onthology/test_string_attribute.py
+++ b/tests/validation/validate_onthology/test_string_attribute.py
@@ -1,0 +1,88 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._string_attribute import (
+    _StringAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_integer_attribute_dict():
+    return {"attribute_type": "integer", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+def test_supports__empty_dict():
+    assert not _StringAttribute.supports({})
+
+
+def test_supports__correct(example_string_attribute_dict):
+    assert _StringAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_int(example_integer_attribute_dict):
+    assert not _StringAttribute.supports(example_integer_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_single_select_attribute_dict):
+    assert not _StringAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _StringAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_string_attribute_dict):
+    for val in [False, True]:
+        example_string_attribute_dict["optional"] = val
+        assert _StringAttribute.fromdict(example_string_attribute_dict).optional == val
+
+
+def test_fromdict__scope_invalid(example_string_attribute_dict):
+    with pytest.raises(ValueError):
+        example_string_attribute_dict["scope"] = "some random string"
+        _StringAttribute.fromdict(example_string_attribute_dict)
+
+
+def test_fromdict__scope_annotation(example_string_attribute_dict):
+    example_string_attribute_dict["scope"] = "annotation"
+    assert _StringAttribute.fromdict(example_string_attribute_dict).scope == _Scope.ANNOTATION
+
+
+def test_fromdict__scope_frame(example_string_attribute_dict):
+    example_string_attribute_dict["scope"] = "frame"
+    assert _StringAttribute.fromdict(example_string_attribute_dict).scope == _Scope.FRAME
+
+
+def test_fromdict__scope_object(example_string_attribute_dict):
+    example_string_attribute_dict["scope"] = "object"
+    assert _StringAttribute.fromdict(example_string_attribute_dict).scope == _Scope.OBJECT
+
+
+def test_check_type_and_value__wrong_type(example_string_attribute_dict):
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    errors = attr.check_type_and_value("example_name", 42, IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_type_and_value__correct(example_string_attribute_dict):
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    assert attr.check_type_and_value("example_name", "example_value", IssueIdentifiers()) == []

--- a/tests/validation/validate_onthology/test_string_attribute.py
+++ b/tests/validation/validate_onthology/test_string_attribute.py
@@ -10,24 +10,6 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
-@pytest.fixture
-def example_string_attribute_dict():
-    return {"attribute_type": "string", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_integer_attribute_dict():
-    return {"attribute_type": "integer", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_single_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
 def test_supports__empty_dict():
     assert not _StringAttribute.supports({})
 

--- a/tests/validation/validate_onthology/test_validate_onthology.py
+++ b/tests/validation/validate_onthology/test_validate_onthology.py
@@ -1,0 +1,38 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pathlib import Path
+
+from raillabel_providerkit.validation.validate_onthology.validate_onthology import (
+    validate_onthology,
+    _validate_onthology_schema,
+    _load_onthology,
+    OnthologySchemaError,
+)
+
+ONTHOLOGY_PATH = Path(__file__).parent.parent.parent / "__assets__/osdar23_onthology.yaml"
+
+
+@pytest.fixture
+def onthology_dict() -> dict:
+    return _load_onthology(ONTHOLOGY_PATH)
+
+
+def test_validate_onthology_schema__none():
+    with pytest.raises(OnthologySchemaError):
+        _validate_onthology_schema(None)
+
+
+def test_validate_onthology_schema__empty():
+    _validate_onthology_schema({})
+
+
+def test_validate_onthology_schema__invalid():
+    invalid_dict = {"foo": "bar"}
+    with pytest.raises(OnthologySchemaError):
+        _validate_onthology_schema(invalid_dict)
+
+
+def test_validate_onthology_schema__valid(onthology_dict):
+    _validate_onthology_schema(onthology_dict)

--- a/tests/validation/validate_onthology/test_validate_onthology.py
+++ b/tests/validation/validate_onthology/test_validate_onthology.py
@@ -3,6 +3,7 @@
 
 import pytest
 from pathlib import Path
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_onthology.validate_onthology import (
     validate_onthology,
@@ -10,13 +11,80 @@ from raillabel_providerkit.validation.validate_onthology.validate_onthology impo
     _load_onthology,
     OnthologySchemaError,
 )
+from raillabel_providerkit.validation import IssueType
+from raillabel.scene_builder import SceneBuilder
+from raillabel.format import Point2d, Size2d
 
 ONTHOLOGY_PATH = Path(__file__).parent.parent.parent / "__assets__/osdar23_onthology.yaml"
 
 
 @pytest.fixture
-def onthology_dict() -> dict:
-    return _load_onthology(ONTHOLOGY_PATH)
+def example_onthology_dict() -> dict:
+    return {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "annotation"}}}
+
+
+def test_validate_onthology__empty_scene(example_onthology_dict):
+    scene = SceneBuilder.empty().result
+    issues = validate_onthology(scene, example_onthology_dict)
+    assert issues == []
+
+
+def test_validate_onthology__correct(example_onthology_dict):
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="banana",
+            object_name="banana_0001",
+        )
+        .add_bbox(
+            UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=0,
+            object_name="banana_0001",
+            sensor_id="rgb_center",
+            attributes={"is_peelable": True},
+        )
+        .result
+    )
+    issues = validate_onthology(scene, example_onthology_dict)
+    assert issues == []
+
+
+def test_validate_onthology__invalid_attribute_type(example_onthology_dict):
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="banana",
+            object_name="banana_0001",
+        )
+        .add_bbox(
+            UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+            pos=Point2d(0, 0),
+            size=Size2d(1, 1),
+            frame_id=0,
+            object_name="banana_0001",
+            sensor_id="rgb_center",
+            attributes={"is_peelable": "i-like-trains"},
+        )
+        .result
+    )
+    issues = validate_onthology(scene, example_onthology_dict)
+    assert len(issues) == 1
+    assert issues[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_load_onthology__invalid_path():
+    invalid_path = Path("/this/should/point/nowhere")
+    with pytest.raises(FileNotFoundError):
+        _load_onthology(invalid_path)
+
+
+def test_load_onthology__osdar23():
+    onthology_dict = _load_onthology(ONTHOLOGY_PATH)
+    assert isinstance(onthology_dict, dict)
 
 
 def test_validate_onthology_schema__none():
@@ -34,5 +102,5 @@ def test_validate_onthology_schema__invalid():
         _validate_onthology_schema(invalid_dict)
 
 
-def test_validate_onthology_schema__valid(onthology_dict):
-    _validate_onthology_schema(onthology_dict)
+def test_validate_onthology_schema__valid(example_onthology_dict):
+    _validate_onthology_schema(example_onthology_dict)

--- a/tests/validation/validate_onthology/test_vector_attribute.py
+++ b/tests/validation/validate_onthology/test_vector_attribute.py
@@ -10,24 +10,6 @@ from raillabel_providerkit.validation.validate_onthology._onthology_classes._att
 from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
-@pytest.fixture
-def example_vector_attribute_dict():
-    return {"attribute_type": "vector", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_string_attribute_dict():
-    return {"attribute_type": "string", "scope": "annotation"}
-
-
-@pytest.fixture
-def example_single_select_attribute_dict():
-    return {
-        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
-        "scope": "annotation",
-    }
-
-
 def test_supports__empty_dict():
     assert not _VectorAttribute.supports({})
 

--- a/tests/validation/validate_onthology/test_vector_attribute.py
+++ b/tests/validation/validate_onthology/test_vector_attribute.py
@@ -1,0 +1,88 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_onthology._onthology_classes._attributes._vector_attribute import (
+    _VectorAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+@pytest.fixture
+def example_vector_attribute_dict():
+    return {"attribute_type": "vector", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_string_attribute_dict():
+    return {"attribute_type": "string", "scope": "annotation"}
+
+
+@pytest.fixture
+def example_single_select_attribute_dict():
+    return {
+        "attribute_type": {"type": "single-select", "options": ["foo", "bar"]},
+        "scope": "annotation",
+    }
+
+
+def test_supports__empty_dict():
+    assert not _VectorAttribute.supports({})
+
+
+def test_supports__correct(example_vector_attribute_dict):
+    assert _VectorAttribute.supports(example_vector_attribute_dict)
+
+
+def test_supports__invalid_type_string(example_string_attribute_dict):
+    assert not _VectorAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_single_select_attribute_dict):
+    assert not _VectorAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _VectorAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_vector_attribute_dict):
+    for val in [False, True]:
+        example_vector_attribute_dict["optional"] = val
+        assert _VectorAttribute.fromdict(example_vector_attribute_dict).optional == val
+
+
+def test_fromdict__scope_invalid(example_vector_attribute_dict):
+    with pytest.raises(ValueError):
+        example_vector_attribute_dict["scope"] = "some random string"
+        _VectorAttribute.fromdict(example_vector_attribute_dict)
+
+
+def test_fromdict__scope_annotation(example_vector_attribute_dict):
+    example_vector_attribute_dict["scope"] = "annotation"
+    assert _VectorAttribute.fromdict(example_vector_attribute_dict).scope == _Scope.ANNOTATION
+
+
+def test_fromdict__scope_frame(example_vector_attribute_dict):
+    example_vector_attribute_dict["scope"] = "frame"
+    assert _VectorAttribute.fromdict(example_vector_attribute_dict).scope == _Scope.FRAME
+
+
+def test_fromdict__scope_object(example_vector_attribute_dict):
+    example_vector_attribute_dict["scope"] = "object"
+    assert _VectorAttribute.fromdict(example_vector_attribute_dict).scope == _Scope.OBJECT
+
+
+def test_check_type_and_value__wrong_type(example_vector_attribute_dict):
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    errors = attr.check_type_and_value("example_name", 42, IssueIdentifiers())
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_TYPE
+
+
+def test_check_type_and_value__correct(example_vector_attribute_dict):
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert attr.check_type_and_value("example_name", ["foo", "bar"], IssueIdentifiers()) == []


### PR DESCRIPTION
The existing validate_onthology code has been completely refactored to support raillabel 4 and to make use of other changes in the codebase (new issue format etc.). Additionally, to prepare for further validation functionality, the onthology now includes scopes on the attribute level.

Tests have been added for all validate_onthology functions/classes and pass.

I would appreciate feedback on where to place the onthology for OSDaR23 in the codebase, as tests/__assets__ feels like the wrong location.