### PR TITLE
feat: add attribute type 'any' to validate_ontology

### DIFF
--- a/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_attributes/_any_attribute.py
+++ b/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_attributes/_any_attribute.py
@@ -1,0 +1,39 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from raillabel_providerkit.validation import Issue, IssueIdentifiers
+from raillabel_providerkit.validation.validate_ontology._ontology_classes._scope import (
+    _Scope,
+)
+
+from ._attribute_abc import _Attribute
+
+
+@dataclass
+class _AnyAttribute(_Attribute):
+    @classmethod
+    def supports(cls, attribute_dict: dict) -> bool:
+        return "attribute_type" in attribute_dict and attribute_dict["attribute_type"] == "any"
+
+    @classmethod
+    def fromdict(cls, attribute_dict: dict) -> _AnyAttribute:
+        if not cls.supports(attribute_dict):
+            raise ValueError
+
+        return _AnyAttribute(
+            optional=attribute_dict.get("optional", False),
+            scope=_Scope(attribute_dict.get("scope", "annotation")),
+            sensor_types=attribute_dict.get("sensor_types", ["camera", "lidar", "radar"]),
+        )
+
+    def check_type_and_value(
+        self,
+        attribute_name: str,  # noqa: ARG002
+        attribute_value: bool | float | str | list,  # noqa: ARG002
+        identifiers: IssueIdentifiers,  # noqa: ARG002
+    ) -> list[Issue]:
+        return []

--- a/raillabel_providerkit/validation/validate_ontology/ontology_schema_v2.yaml
+++ b/raillabel_providerkit/validation/validate_ontology/ontology_schema_v2.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 "$schema": http://json-schema.org/draft-07/schema#
-version: 2.1.0
+version: 2.2.0
 
 definitions:
 
@@ -25,6 +25,7 @@ definitions:
     attribute_type:
         oneOf:
             [
+                "$ref": "#/definitions/any_attribute",
                 "$ref": "#/definitions/boolean_attribute",
                 "$ref": "#/definitions/integer_attribute",
                 "$ref": "#/definitions/multi_reference_attribute",
@@ -33,6 +34,9 @@ definitions:
                 "$ref": "#/definitions/string_attribute",
                 "$ref": "#/definitions/vector_attribute",
             ]
+
+    any_attribute:
+        const: any
 
     boolean_attribute:
         const: boolean

--- a/tests/validation/validate_ontology/conftest.py
+++ b/tests/validation/validate_ontology/conftest.py
@@ -5,6 +5,11 @@ import pytest
 
 
 @pytest.fixture
+def example_any_attribute_dict():
+    return {"attribute_type": "any", "scope": "annotation"}
+
+
+@pytest.fixture
 def example_boolean_attribute_dict():
     return {"attribute_type": "boolean", "scope": "annotation"}
 

--- a/tests/validation/validate_ontology/test_any_attribute.py
+++ b/tests/validation/validate_ontology/test_any_attribute.py
@@ -1,0 +1,86 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from raillabel_providerkit.validation.validate_ontology._ontology_classes._scope import _Scope
+from raillabel_providerkit.validation.validate_ontology._ontology_classes._attributes._any_attribute import (
+    _AnyAttribute,
+)
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
+
+
+def test_supports__empty_dict():
+    assert not _AnyAttribute.supports({})
+
+
+def test_supports__correct(example_any_attribute_dict):
+    assert _AnyAttribute.supports(example_any_attribute_dict)
+
+
+def test_supports__invalid_type_string(example_string_attribute_dict):
+    assert not _AnyAttribute.supports(example_string_attribute_dict)
+
+
+def test_supports__invalid_type_dict(example_single_select_attribute_dict):
+    assert not _AnyAttribute.supports(example_single_select_attribute_dict)
+
+
+def test_fromdict__empty():
+    with pytest.raises(ValueError):
+        _AnyAttribute.fromdict({})
+
+
+def test_fromdict__optional(example_any_attribute_dict):
+    for val in [False, True]:
+        example_any_attribute_dict["optional"] = val
+        assert _AnyAttribute.fromdict(example_any_attribute_dict).optional == val
+
+
+def test_fromdict__scope_invalid(example_any_attribute_dict):
+    with pytest.raises(ValueError):
+        example_any_attribute_dict["scope"] = "some random string"
+        _AnyAttribute.fromdict(example_any_attribute_dict)
+
+
+def test_fromdict__scope_empty(example_any_attribute_dict):
+    del example_any_attribute_dict["scope"]
+    assert _AnyAttribute.fromdict(example_any_attribute_dict).scope == _Scope.ANNOTATION
+
+
+def test_fromdict__scope_annotation(example_any_attribute_dict):
+    example_any_attribute_dict["scope"] = "annotation"
+    assert _AnyAttribute.fromdict(example_any_attribute_dict).scope == _Scope.ANNOTATION
+
+
+def test_fromdict__scope_frame(example_any_attribute_dict):
+    example_any_attribute_dict["scope"] = "frame"
+    assert _AnyAttribute.fromdict(example_any_attribute_dict).scope == _Scope.FRAME
+
+
+def test_fromdict__scope_object(example_any_attribute_dict):
+    example_any_attribute_dict["scope"] = "object"
+    assert _AnyAttribute.fromdict(example_any_attribute_dict).scope == _Scope.OBJECT
+
+
+def test_check_type_and_value__correct_boolean(example_any_attribute_dict):
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert attr.check_type_and_value("example_name", True, IssueIdentifiers()) == []
+
+
+def test_check_type_and_value__correct_string(example_any_attribute_dict):
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert attr.check_type_and_value("example_name", "hello_there", IssueIdentifiers()) == []
+
+
+def test_check_type_and_value__correct_int(example_any_attribute_dict):
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert attr.check_type_and_value("example_name", 42, IssueIdentifiers()) == []
+
+
+def test_check_type_and_value__correct_list(example_any_attribute_dict):
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_type_and_value("example_name", ["this", "is", "a", "test"], IssueIdentifiers())
+        == []
+    )


### PR DESCRIPTION
This PR adds a new attribute type "any" to validate_ontology. This attribute type allows all data types and values.