### PR TITLE
Add attribute scope validation

### DIFF
--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -11,6 +11,7 @@ class IssueType(Enum):
 
     SCHEMA = "SchemaIssue"
     ATTRIBUTE_MISSING = "AttributeMissing"
+    ATTRIBUTE_SCOPE = "AttributeScopeInconsistency"
     ATTRIBUTE_TYPE = "AttributeTypeIssue"
     ATTRIBUTE_UNDEFINED = "AttributeUndefined"
     ATTRIBUTE_VALUE = "AttributeValueIssue"

--- a/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_attributes/_attribute_abc.py
+++ b/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_attributes/_attribute_abc.py
@@ -107,8 +107,7 @@ class _Attribute(abc.ABC):
         # If the attribute is a list, it is not an error if the lists have the same
         # values, but are in a different order
         if (
-            self.PYTHON_TYPE is list
-            and type(attribute_value_1) is list
+            type(attribute_value_1) is list
             and type(attribute_value_2) is list
             and Counter(attribute_value_1) == Counter(attribute_value_2)
         ):

--- a/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_ontology.py
+++ b/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_ontology.py
@@ -37,6 +37,8 @@ class _Ontology:
                 self.classes[annotation_metadata.object_type].check(annotation_metadata)
             )
 
+        self.errors.extend(self._check_attribute_scopes(annotations))
+
         return self.errors
 
     def _check_class_validity(self, scene: raillabel.Scene) -> None:
@@ -49,6 +51,45 @@ class _Ontology:
                         identifiers=IssueIdentifiers(object=obj_uid, object_type=object_class),
                     )
                 )
+
+    def _check_attribute_scopes(
+        self, annotations_with_metadata: list[_AnnotationWithMetadata]
+    ) -> list[Issue]:
+        errors: list[Issue] = []
+        checked_attributes_by_object_type: dict[str, list[str]] = {}
+
+        for annotation_with_metadata in annotations_with_metadata:
+            object_type = annotation_with_metadata.object_type
+
+            if object_type not in self.classes:
+                continue
+            object_class = self.classes[object_type]
+
+            if object_type not in checked_attributes_by_object_type:
+                checked_attributes_by_object_type[object_type] = []
+
+            for attribute_name in annotation_with_metadata.annotation.attributes:
+                attribute = object_class.attributes.get(attribute_name)
+                if attribute is None:
+                    continue
+
+                if attribute_name in checked_attributes_by_object_type[object_type]:
+                    continue
+                checked_attributes_by_object_type[object_type].append(attribute_name)
+
+                scope = attribute.scope
+
+                for other_annotation_with_metadata in annotations_with_metadata:
+                    errors.extend(
+                        attribute.check_scope_for_two_annotations(
+                            attribute_name,
+                            scope,
+                            annotation_with_metadata,
+                            other_annotation_with_metadata,
+                        )
+                    )
+
+        return errors
 
     @classmethod
     def _compile_annotations(cls, scene: raillabel.Scene) -> list[_AnnotationWithMetadata]:

--- a/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_ontology.py
+++ b/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_ontology.py
@@ -59,14 +59,15 @@ class _Ontology:
         checked_attributes_by_object_type: dict[str, list[str]] = {}
 
         for annotation_with_metadata in annotations_with_metadata:
-            object_type = annotation_with_metadata.object_type
+            object_type_name = annotation_with_metadata.object_type
 
-            if object_type not in self.classes:
+            if object_type_name not in self.classes:
+                # NOTE: This is an UNEXPECTED_CLASS issue and handled elsewhere.
                 continue
-            object_class = self.classes[object_type]
+            object_class = self.classes[object_type_name]
 
-            if object_type not in checked_attributes_by_object_type:
-                checked_attributes_by_object_type[object_type] = []
+            if object_type_name not in checked_attributes_by_object_type:
+                checked_attributes_by_object_type[object_type_name] = []
 
             for (
                 attribute_name,
@@ -76,14 +77,14 @@ class _Ontology:
                 if attribute is None:
                     continue
 
-                if attribute_name in checked_attributes_by_object_type[object_type]:
+                if attribute_name in checked_attributes_by_object_type[object_type_name]:
                     continue
-                checked_attributes_by_object_type[object_type].append(attribute_name)
+                checked_attributes_by_object_type[object_type_name].append(attribute_name)
 
                 for other_annotation_with_metadata in annotations_with_metadata:
                     if (
                         other_annotation_with_metadata is annotations_with_metadata
-                        or other_annotation_with_metadata.object_type != object_type
+                        or other_annotation_with_metadata.object_type != object_type_name
                     ):
                         continue
 

--- a/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_ontology.py
+++ b/raillabel_providerkit/validation/validate_ontology/_ontology_classes/_ontology.py
@@ -68,7 +68,10 @@ class _Ontology:
             if object_type not in checked_attributes_by_object_type:
                 checked_attributes_by_object_type[object_type] = []
 
-            for attribute_name in annotation_with_metadata.annotation.attributes:
+            for (
+                attribute_name,
+                attribute_value,
+            ) in annotation_with_metadata.annotation.attributes.items():
                 attribute = object_class.attributes.get(attribute_name)
                 if attribute is None:
                     continue
@@ -77,15 +80,26 @@ class _Ontology:
                     continue
                 checked_attributes_by_object_type[object_type].append(attribute_name)
 
-                scope = attribute.scope
-
                 for other_annotation_with_metadata in annotations_with_metadata:
+                    if (
+                        other_annotation_with_metadata is annotations_with_metadata
+                        or other_annotation_with_metadata.object_type != object_type
+                    ):
+                        continue
+
+                    if attribute_name not in other_annotation_with_metadata.annotation.attributes:
+                        return []
+                    other_attribute_value = other_annotation_with_metadata.annotation.attributes[
+                        attribute_name
+                    ]
+
                     errors.extend(
                         attribute.check_scope_for_two_annotations(
                             attribute_name,
-                            scope,
-                            annotation_with_metadata,
-                            other_annotation_with_metadata,
+                            attribute_value,
+                            other_attribute_value,
+                            annotation_with_metadata.to_identifiers(attribute_name),
+                            other_annotation_with_metadata.to_identifiers(attribute_name),
                         )
                     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,3 +115,28 @@ def empty_annotation() -> raillabel.format.Bbox:
 @pytest.fixture
 def ignore_uuid() -> UUID:
     return UUID("00000000-0000-0000-0000-000000000000")
+
+
+@pytest.fixture
+def sample_uuid_1() -> UUID:
+    return UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture
+def sample_uuid_2() -> UUID:
+    return UUID("00000000-0000-0000-0000-000000000002")
+
+
+@pytest.fixture
+def sample_uuid_3() -> UUID:
+    return UUID("00000000-0000-0000-0000-000000000003")
+
+
+@pytest.fixture
+def sample_uuid_4() -> UUID:
+    return UUID("00000000-0000-0000-0000-000000000004")
+
+
+@pytest.fixture
+def sample_uuid_5() -> UUID:
+    return UUID("00000000-0000-0000-0000-000000000005")

--- a/tests/validation/validate_ontology/test_any_attribute.py
+++ b/tests/validation/validate_ontology/test_any_attribute.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_ontology._ontology_classes import (
     _Scope,
     _AnyAttribute,
 )
-from raillabel_providerkit.validation import IssueIdentifiers
+from raillabel_providerkit.validation import IssueIdentifiers, IssueType
 
 
 def test_supports__empty_dict():
@@ -82,5 +83,144 @@ def test_check_type_and_value__correct_list(example_any_attribute_dict):
     attr = _AnyAttribute.fromdict(example_any_attribute_dict)
     assert (
         attr.check_type_and_value("example_name", ["this", "is", "a", "test"], IssueIdentifiers())
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__ignore_unmatched_types(
+    example_any_attribute_dict,
+):
+    example_any_attribute_dict["scope"] = "annotation"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", ["foo"], 42, IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__annotation_correct(example_any_attribute_dict):
+    example_any_attribute_dict["scope"] = "annotation"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", ["foo"], ["bar"], IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_same_frame(
+    example_any_attribute_dict, ignore_uuid
+):
+    example_any_attribute_dict["scope"] = "frame"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["foo"],
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_different_frame(
+    example_any_attribute_dict, ignore_uuid
+):
+    example_any_attribute_dict["scope"] = "frame"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["bar"],
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=73, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_inconsistent(
+    example_any_attribute_dict, ignore_uuid
+):
+    example_any_attribute_dict["scope"] = "frame"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        ["foo"],
+        ["bar"],
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_same_object(
+    example_any_attribute_dict,
+):
+    example_any_attribute_dict["scope"] = "object"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["foo"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_correct_different_object(
+    example_any_attribute_dict,
+):
+    example_any_attribute_dict["scope"] = "object"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["bar"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("98e93d07-e81a-4827-8c62-a82c3c4bfc42")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_inconsistent(example_any_attribute_dict):
+    example_any_attribute_dict["scope"] = "object"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        ["foo"],
+        ["bar"],
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_different_order(
+    example_any_attribute_dict,
+):
+    example_any_attribute_dict["scope"] = "object"
+    attr = _AnyAttribute.fromdict(example_any_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo", "bar"],
+            ["bar", "foo"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
         == []
     )

--- a/tests/validation/validate_ontology/test_boolean_attribute.py
+++ b/tests/validation/validate_ontology/test_boolean_attribute.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_ontology._ontology_classes import (
     _Scope,
@@ -73,3 +74,121 @@ def test_check_type_and_value__wrong_type(example_boolean_attribute_dict):
 def test_check_type_and_value__correct(example_boolean_attribute_dict):
     attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
     assert attr.check_type_and_value("example_name", True, IssueIdentifiers()) == []
+
+
+def test_check_scope_for_two_annotations__ignore_unmatched_types(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["scope"] = "annotation"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", True, "value_of_some_other_type", IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__annotation_correct(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["scope"] = "annotation"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", True, False, IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_same_frame(
+    example_boolean_attribute_dict, ignore_uuid
+):
+    example_boolean_attribute_dict["scope"] = "frame"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            True,
+            True,
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_different_frame(
+    example_boolean_attribute_dict, ignore_uuid
+):
+    example_boolean_attribute_dict["scope"] = "frame"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            True,
+            False,
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=73, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_inconsistent(
+    example_boolean_attribute_dict, ignore_uuid
+):
+    example_boolean_attribute_dict["scope"] = "frame"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        True,
+        False,
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_same_object(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["scope"] = "object"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            True,
+            True,
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_correct_different_object(
+    example_boolean_attribute_dict,
+):
+    example_boolean_attribute_dict["scope"] = "object"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            True,
+            False,
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("98e93d07-e81a-4827-8c62-a82c3c4bfc42")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_inconsistent(example_boolean_attribute_dict):
+    example_boolean_attribute_dict["scope"] = "object"
+    attr = _BooleanAttribute.fromdict(example_boolean_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        True,
+        False,
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE

--- a/tests/validation/validate_ontology/test_integer_attribute.py
+++ b/tests/validation/validate_ontology/test_integer_attribute.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_ontology._ontology_classes import (
     _Scope,
@@ -73,3 +74,121 @@ def test_check_type_and_value__wrong_type(example_integer_attribute_dict):
 def test_check_type_and_value__correct(example_integer_attribute_dict):
     attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
     assert attr.check_type_and_value("example_name", 42, IssueIdentifiers()) == []
+
+
+def test_check_scope_for_two_annotations__ignore_unmatched_types(example_integer_attribute_dict):
+    example_integer_attribute_dict["scope"] = "annotation"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", 123, "value_of_some_other_type", IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__annotation_correct(example_integer_attribute_dict):
+    example_integer_attribute_dict["scope"] = "annotation"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", 123, 456, IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_same_frame(
+    example_integer_attribute_dict, ignore_uuid
+):
+    example_integer_attribute_dict["scope"] = "frame"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            123,
+            123,
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_different_frame(
+    example_integer_attribute_dict, ignore_uuid
+):
+    example_integer_attribute_dict["scope"] = "frame"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            123,
+            456,
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=73, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_inconsistent(
+    example_integer_attribute_dict, ignore_uuid
+):
+    example_integer_attribute_dict["scope"] = "frame"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        123,
+        456,
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_same_object(example_integer_attribute_dict):
+    example_integer_attribute_dict["scope"] = "object"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            123,
+            123,
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_correct_different_object(
+    example_integer_attribute_dict,
+):
+    example_integer_attribute_dict["scope"] = "object"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            123,
+            456,
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("98e93d07-e81a-4827-8c62-a82c3c4bfc42")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_inconsistent(example_integer_attribute_dict):
+    example_integer_attribute_dict["scope"] = "object"
+    attr = _IntegerAttribute.fromdict(example_integer_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        True,
+        False,
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE

--- a/tests/validation/validate_ontology/test_multi_reference_attribute.py
+++ b/tests/validation/validate_ontology/test_multi_reference_attribute.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_ontology._ontology_classes import (
     _Scope,
@@ -98,6 +99,155 @@ def test_check_type_and_value__correct(example_multi_reference_attribute_dict):
             "example_name",
             ["29b15a46-ccf7-48f8-8269-ce47285e544e", "fcc35567-7559-421e-acdc-89287e5a8c9c"],
             IssueIdentifiers(),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__ignore_unmatched_types(
+    example_multi_reference_attribute_dict,
+):
+    example_multi_reference_attribute_dict["scope"] = "annotation"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            42,
+            IssueIdentifiers(),
+            IssueIdentifiers(),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__annotation_correct(example_multi_reference_attribute_dict):
+    example_multi_reference_attribute_dict["scope"] = "annotation"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            ["fcc35567-7559-421e-acdc-89287e5a8c9c"],
+            IssueIdentifiers(),
+            IssueIdentifiers(),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_same_frame(
+    example_multi_reference_attribute_dict, ignore_uuid
+):
+    example_multi_reference_attribute_dict["scope"] = "frame"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_different_frame(
+    example_multi_reference_attribute_dict, ignore_uuid
+):
+    example_multi_reference_attribute_dict["scope"] = "frame"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            ["fcc35567-7559-421e-acdc-89287e5a8c9c"],
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=73, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_inconsistent(
+    example_multi_reference_attribute_dict, ignore_uuid
+):
+    example_multi_reference_attribute_dict["scope"] = "frame"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+        ["fcc35567-7559-421e-acdc-89287e5a8c9c"],
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_same_object(
+    example_multi_reference_attribute_dict,
+):
+    example_multi_reference_attribute_dict["scope"] = "object"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_correct_different_object(
+    example_multi_reference_attribute_dict,
+):
+    example_multi_reference_attribute_dict["scope"] = "object"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            ["fcc35567-7559-421e-acdc-89287e5a8c9c"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("98e93d07-e81a-4827-8c62-a82c3c4bfc42")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_inconsistent(
+    example_multi_reference_attribute_dict,
+):
+    example_multi_reference_attribute_dict["scope"] = "object"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        ["29b15a46-ccf7-48f8-8269-ce47285e544e"],
+        ["fcc35567-7559-421e-acdc-89287e5a8c9c"],
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_different_order(
+    example_multi_reference_attribute_dict,
+):
+    example_multi_reference_attribute_dict["scope"] = "object"
+    attr = _MultiReferenceAttribute.fromdict(example_multi_reference_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["29b15a46-ccf7-48f8-8269-ce47285e544e", "fcc35567-7559-421e-acdc-89287e5a8c9c"],
+            ["fcc35567-7559-421e-acdc-89287e5a8c9c", "29b15a46-ccf7-48f8-8269-ce47285e544e"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
         )
         == []
     )

--- a/tests/validation/validate_ontology/test_ontology.py
+++ b/tests/validation/validate_ontology/test_ontology.py
@@ -116,6 +116,53 @@ def test_check__invalid_attribute_type():
     )
 
 
+def test_check__scope_inconsistency():
+    ontology = _Ontology.fromdict(
+        {"banana": {"is_peelable": {"attribute_type": "boolean", "scope": "frame"}}}
+    )
+    scene = (
+        SceneBuilder.empty()
+        .add_object(
+            object_id=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+            object_type="banana",
+            object_name="banana_0001",
+        )
+        .add_bbox(
+            UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+            frame_id=0,
+            object_name="banana_0001",
+            sensor_id="rgb_center",
+            attributes={"is_peelable": True},
+        )
+        .add_bbox(
+            UUID("0ef548ab-70bc-4e74-9e11-76cff46ada0f"),
+            frame_id=0,
+            object_name="banana_0001",
+            sensor_id="rgb_left",
+            attributes={"is_peelable": False},
+        )
+        .result
+    )
+    issues = ontology.check(scene)
+    assert len(issues) == 1
+    assert issues[0].type == IssueType.ATTRIBUTE_SCOPE
+    assert issues[0].identifiers == IssueIdentifiers(
+        annotation=UUID("f54d41d6-5e36-490b-9efc-05a6deb7549a"),
+        attribute="is_peelable",
+        frame=0,
+        object=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+        object_type="banana",
+        sensor="rgb_center",
+    ) or issues[0].identifiers == IssueIdentifiers(
+        annotation=UUID("0ef548ab-70bc-4e74-9e11-76cff46ada0f"),
+        attribute="is_peelable",
+        frame=0,
+        object=UUID("ba73e75d-b996-4f6e-bdad-39c465420a33"),
+        object_type="banana",
+        sensor="rgb_left",
+    )
+
+
 def test_check_class_validity__empty_scene():
     ontology = _Ontology.fromdict({})
     scene = SceneBuilder.empty().result

--- a/tests/validation/validate_ontology/test_single_select_attribute.py
+++ b/tests/validation/validate_ontology/test_single_select_attribute.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_ontology._ontology_classes import (
     _Scope,
@@ -90,3 +91,125 @@ def test_check_type_and_value__wrong_value(example_single_select_attribute_dict)
 def test_check_type_and_value__correct(example_single_select_attribute_dict):
     attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
     assert attr.check_type_and_value("example_name", "foo", IssueIdentifiers()) == []
+
+
+def test_check_scope_for_two_annotations__ignore_unmatched_types(
+    example_single_select_attribute_dict,
+):
+    example_single_select_attribute_dict["scope"] = "annotation"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", "foo", 42, IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__annotation_correct(example_single_select_attribute_dict):
+    example_single_select_attribute_dict["scope"] = "annotation"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", "foo", "bar", IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_same_frame(
+    example_single_select_attribute_dict, ignore_uuid
+):
+    example_single_select_attribute_dict["scope"] = "frame"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "foo",
+            "foo",
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_different_frame(
+    example_single_select_attribute_dict, ignore_uuid
+):
+    example_single_select_attribute_dict["scope"] = "frame"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "foo",
+            "bar",
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=73, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_inconsistent(
+    example_single_select_attribute_dict, ignore_uuid
+):
+    example_single_select_attribute_dict["scope"] = "frame"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        "foo",
+        "bar",
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_same_object(
+    example_single_select_attribute_dict,
+):
+    example_single_select_attribute_dict["scope"] = "object"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "foo",
+            "foo",
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_correct_different_object(
+    example_single_select_attribute_dict,
+):
+    example_single_select_attribute_dict["scope"] = "object"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "foo",
+            "bar",
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("98e93d07-e81a-4827-8c62-a82c3c4bfc42")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_inconsistent(example_single_select_attribute_dict):
+    example_single_select_attribute_dict["scope"] = "object"
+    attr = _SingleSelectAttribute.fromdict(example_single_select_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        "foo",
+        "bar",
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE

--- a/tests/validation/validate_ontology/test_string_attribute.py
+++ b/tests/validation/validate_ontology/test_string_attribute.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_ontology._ontology_classes import (
     _Scope,
@@ -73,3 +74,121 @@ def test_check_type_and_value__wrong_type(example_string_attribute_dict):
 def test_check_type_and_value__correct(example_string_attribute_dict):
     attr = _StringAttribute.fromdict(example_string_attribute_dict)
     assert attr.check_type_and_value("example_name", "example_value", IssueIdentifiers()) == []
+
+
+def test_check_scope_for_two_annotations__ignore_unmatched_types(example_string_attribute_dict):
+    example_string_attribute_dict["scope"] = "annotation"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", "Hello There!", 42, IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__annotation_correct(example_string_attribute_dict):
+    example_string_attribute_dict["scope"] = "annotation"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", "hello", "goodbye", IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_same_frame(
+    example_string_attribute_dict, ignore_uuid
+):
+    example_string_attribute_dict["scope"] = "frame"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "hello",
+            "hello",
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_different_frame(
+    example_string_attribute_dict, ignore_uuid
+):
+    example_string_attribute_dict["scope"] = "frame"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "hello",
+            "goodbye",
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=73, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_inconsistent(
+    example_string_attribute_dict, ignore_uuid
+):
+    example_string_attribute_dict["scope"] = "frame"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        "hello",
+        "goodbye",
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_same_object(example_string_attribute_dict):
+    example_string_attribute_dict["scope"] = "object"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "hello",
+            "hello",
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_correct_different_object(
+    example_string_attribute_dict,
+):
+    example_string_attribute_dict["scope"] = "object"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            "hello",
+            "goodbye",
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("98e93d07-e81a-4827-8c62-a82c3c4bfc42")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_inconsistent(example_string_attribute_dict):
+    example_string_attribute_dict["scope"] = "object"
+    attr = _StringAttribute.fromdict(example_string_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        "hello",
+        "goodbye",
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE

--- a/tests/validation/validate_ontology/test_vector_attribute.py
+++ b/tests/validation/validate_ontology/test_vector_attribute.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from uuid import UUID
 
 from raillabel_providerkit.validation.validate_ontology._ontology_classes import (
     _Scope,
@@ -73,3 +74,142 @@ def test_check_type_and_value__wrong_type(example_vector_attribute_dict):
 def test_check_type_and_value__correct(example_vector_attribute_dict):
     attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
     assert attr.check_type_and_value("example_name", ["foo", "bar"], IssueIdentifiers()) == []
+
+
+def test_check_scope_for_two_annotations__ignore_unmatched_types(
+    example_vector_attribute_dict,
+):
+    example_vector_attribute_dict["scope"] = "annotation"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", ["foo"], 42, IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__annotation_correct(example_vector_attribute_dict):
+    example_vector_attribute_dict["scope"] = "annotation"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name", ["foo"], ["bar"], IssueIdentifiers(), IssueIdentifiers()
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_same_frame(
+    example_vector_attribute_dict, ignore_uuid
+):
+    example_vector_attribute_dict["scope"] = "frame"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["foo"],
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_correct_different_frame(
+    example_vector_attribute_dict, ignore_uuid
+):
+    example_vector_attribute_dict["scope"] = "frame"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["bar"],
+            IssueIdentifiers(frame=42, object=ignore_uuid),
+            IssueIdentifiers(frame=73, object=ignore_uuid),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__frame_inconsistent(
+    example_vector_attribute_dict, ignore_uuid
+):
+    example_vector_attribute_dict["scope"] = "frame"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        ["foo"],
+        ["bar"],
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+        IssueIdentifiers(frame=42, object=ignore_uuid),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_same_object(
+    example_vector_attribute_dict,
+):
+    example_vector_attribute_dict["scope"] = "object"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["foo"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_correct_different_object(
+    example_vector_attribute_dict,
+):
+    example_vector_attribute_dict["scope"] = "object"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo"],
+            ["bar"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("98e93d07-e81a-4827-8c62-a82c3c4bfc42")),
+        )
+        == []
+    )
+
+
+def test_check_scope_for_two_annotations__object_inconsistent(example_vector_attribute_dict):
+    example_vector_attribute_dict["scope"] = "object"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    errors = attr.check_scope_for_two_annotations(
+        "example_name",
+        ["foo"],
+        ["bar"],
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+    )
+    assert len(errors) == 1
+    assert errors[0].type == IssueType.ATTRIBUTE_SCOPE
+
+
+def test_check_scope_for_two_annotations__object_correct_different_order(
+    example_vector_attribute_dict,
+):
+    example_vector_attribute_dict["scope"] = "object"
+    attr = _VectorAttribute.fromdict(example_vector_attribute_dict)
+    assert (
+        attr.check_scope_for_two_annotations(
+            "example_name",
+            ["foo", "bar"],
+            ["bar", "foo"],
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+            IssueIdentifiers(frame=42, object=UUID("44de4109-ee2c-4729-956d-8e965c7ce231")),
+        )
+        == []
+    )


### PR DESCRIPTION
This PR adds attribute scope validation functionality to validate_ontology, as well as lots of tests to check some edge cases.