### PR TITLE
Draft: Add CLI for bulk scene validation with optional CSV output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "pyyaml>=6.0.0",
   "numpy>=1.24.4",
   "pydantic<3.0.0",
+  "tqdm>=4.63.0",
 ]
 
 [project.urls]

--- a/raillabel_providerkit/__main__.py
+++ b/raillabel_providerkit/__main__.py
@@ -1,0 +1,161 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+from tqdm import tqdm
+
+from raillabel_providerkit import validate
+from raillabel_providerkit.validation.issue import Issue
+
+OSDAR23_ONTOLOGY_PATH = (
+    Path(__file__).parent.parent / "tests" / "__assets__" / "osdar23_ontology.yaml"
+)
+
+
+def store_issues_to_json(issues: list[Issue], filepath: Path) -> None:
+    """Store the given issues in a .json file under the given filepath.
+
+    Parameters
+    ----------
+    issues : list[Issue]
+        The issues to store
+    filepath : Path
+        The path to the .json file to store the issues in
+    """
+    issues_serialized = [issue.serialize() for issue in issues]
+    issues_json = json.dumps(issues_serialized, indent=2)
+    with Path.open(filepath, "w") as file:
+        file.write(issues_json)
+
+
+def store_issues_to_csv(issues: list[Issue], filepath: Path) -> None:
+    """Store the given issues in a .csv file under the given filepath.
+
+    Parameters
+    ----------
+    issues : list[Issue]
+        The issues to store
+    filepath : Path
+        The path to the .csv file to store the issues in
+
+    Raises
+    ------
+    TypeError
+        If the issues are malformed after serialization
+    """
+    issues_serialized = [issue.serialize() for issue in issues]
+
+    file = Path.open(filepath, "w")
+
+    writer = csv.writer(file, dialect="excel-tab")
+    writer.writerow(
+        [
+            "issue_type",
+            "frame",
+            "sensor",
+            "object_type",
+            "object",
+            "annotation",
+            "attribute",
+            "schema_path",
+            "reason",
+        ]
+    )
+
+    for issue in issues_serialized:
+        issue_type = issue["type"]
+        reason = issue.get("reason", "")
+        if not isinstance(issue_type, str) or not isinstance(reason, str):
+            raise TypeError
+
+        row: list[str | int] = []
+        row.append(issue_type)
+        identifiers = issue["identifiers"]
+        if isinstance(identifiers, dict):
+            row.append(identifiers.get("frame", ""))
+            row.append(identifiers.get("sensor", ""))
+            row.append(identifiers.get("object_type", ""))
+            row.append(identifiers.get("object", ""))
+            row.append(identifiers.get("annotation", ""))
+            row.append(identifiers.get("attribute", ""))
+            row.append("")
+        else:
+            # It's a schema issue, so there are no standard identifiers
+            row.extend(["", "", "", "", "", ""])
+            row.append(str(identifiers))
+        row.append(reason)
+
+        writer.writerow(row)
+
+    file.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="raillabel_providerkit",
+        description="Check a raillabel scene's annotations for errors",
+        allow_abbrev=False,
+    )
+    parser.add_argument(
+        "annotations_folder",
+        help="The path to the folder that contains the annotation scenes to check",
+    )
+    parser.add_argument(
+        "output_folder",
+        help="The path to the folder where the validation results should be output",
+    )
+    parser.add_argument(
+        "--ontology",
+        metavar="FILEPATH",
+        default=str(OSDAR23_ONTOLOGY_PATH),
+        help="The path to the ontology against which to validate attributes of all annotations,"
+        " by default OSDaR23's ontology",
+    )
+    parser.add_argument(
+        "--csv",
+        action="store_true",
+        default=False,
+        help="Create human-readable .csv files containing the issues in addition to .json output",
+    )
+    parser.add_argument(
+        "--no-json",
+        action="store_true",
+        default=False,
+        help="Don't create .json files containing the issues",
+    )
+    args = parser.parse_args()
+
+    annotations_folder = Path(args.annotations_folder)
+    output_folder = Path(args.output_folder)
+    ontology_path = Path(args.ontology)
+    create_csv = args.csv
+    create_json = not args.no_json
+
+    # Stop early if there is nothing to output
+    if not create_csv and not create_json:
+        sys.exit(0)
+
+    # Ensure output folder exists
+    output_folder.mkdir(parents=True, exist_ok=True)
+
+    # Get all scenes (.json files) in the folder and subfolders but ignore hidden folders
+    scene_files = list(
+        set(annotations_folder.glob("**/*.json")) - set(annotations_folder.glob(".*/**/*"))
+    )
+
+    for scene_path in tqdm(scene_files, desc="Validating files"):
+        issues = validate(
+            scene_path,
+            ontology_path,
+        )
+
+        scene_name = scene_path.name
+        if create_json:
+            store_issues_to_json(issues, output_folder / scene_name.replace(".json", ".issues.json"))
+        if create_csv:
+            store_issues_to_csv(issues, output_folder / scene_name.replace(".json", ".issues.csv"))

--- a/raillabel_providerkit/validation/issue.py
+++ b/raillabel_providerkit/validation/issue.py
@@ -36,6 +36,88 @@ class IssueIdentifiers:
     object_type: str | None = None
     sensor: str | None = None
 
+    def serialize(self) -> dict[str, str | int]:
+        """Serialize the IssueIdentifiers into a JSON-compatible dictionary.
+
+        Returns
+        -------
+        dict[str, str | int]
+            The serialized IssueIdentifiers as a JSON-compatible dictionary
+        """
+        serialized_issue_identifiers: dict[str, str | int] = {}
+        if self.annotation is not None:
+            serialized_issue_identifiers["annotation"] = str(self.annotation)
+        if self.attribute is not None:
+            serialized_issue_identifiers["attribute"] = self.attribute
+        if self.frame is not None:
+            serialized_issue_identifiers["frame"] = self.frame
+        if self.object is not None:
+            serialized_issue_identifiers["object"] = str(self.object)
+        if self.object_type is not None:
+            serialized_issue_identifiers["object_type"] = self.object_type
+        if self.sensor is not None:
+            serialized_issue_identifiers["sensor"] = self.sensor
+        return serialized_issue_identifiers
+
+    @classmethod
+    def deserialize(cls, serialized_issue_identifiers: dict[str, str | int]) -> "IssueIdentifiers":  # noqa: C901
+        """Deserialize a JSON-compatible dictionary back into an IssueIdentifiers class instance.
+
+        Parameters
+        ----------
+        serialized_issue_identifiers : dict[str, str  |  int]
+            The serialized IssueIdentifiers as a JSON-compatible dictionary
+
+        Returns
+        -------
+        IssueIdentifiers
+            The deserialized IssueIdentifiers class instance
+
+        Raises
+        ------
+        TypeError
+            If any of the fields have an unexpected type
+        """
+        identifiers = IssueIdentifiers()
+
+        annotation = serialized_issue_identifiers.get("annotation")
+        if isinstance(annotation, int):
+            raise TypeError
+        if annotation is not None:
+            identifiers.annotation = UUID(annotation)
+
+        attribute = serialized_issue_identifiers.get("attribute")
+        if isinstance(attribute, int):
+            raise TypeError
+        if attribute is not None:
+            identifiers.attribute = attribute
+
+        frame = serialized_issue_identifiers.get("frame")
+        if isinstance(frame, str):
+            raise TypeError
+        if frame is not None:
+            identifiers.frame = frame
+
+        object = serialized_issue_identifiers.get("object")  # noqa: A001
+        if isinstance(object, int):
+            raise TypeError
+        if object is not None:
+            identifiers.object = UUID(object)
+
+        object_type = serialized_issue_identifiers.get("object_type")
+        if isinstance(object_type, int):
+            raise TypeError
+        if object_type is not None:
+            identifiers.object_type = object_type
+
+        sensor = serialized_issue_identifiers.get("sensor")
+        if isinstance(sensor, int):
+            raise TypeError
+        if sensor is not None:
+            identifiers.sensor = sensor
+
+        return identifiers
+
 
 @dataclass
 class Issue:
@@ -44,3 +126,60 @@ class Issue:
     type: IssueType
     identifiers: IssueIdentifiers | list[str | int]
     reason: str | None = None
+
+    def serialize(self) -> dict[str, str | dict[str, str | int] | list[str | int]]:
+        """Serialize the Issue into a JSON-compatible dictionary.
+
+        Returns
+        -------
+        dict[str, str | dict[str, str | int] | list[str | int]]
+            The serialized Issue as a JSON-compatible dictionary
+        """
+        serialized_issue = {
+            "type": str(self.type.value),
+            "identifiers": (
+                self.identifiers.serialize()
+                if isinstance(self.identifiers, IssueIdentifiers)
+                else self.identifiers
+            ),
+        }
+        if self.reason is not None:
+            serialized_issue["reason"] = self.reason
+        return serialized_issue
+
+    @classmethod
+    def deserialize(
+        cls, serialized_issue: dict[str, str | dict[str, str | int] | list[str | int]]
+    ) -> "Issue":
+        """Deserialize a JSON-compatible dictionary back into an Issue class instance.
+
+        Parameters
+        ----------
+        serialized_issue : dict[str, str  |  dict[str, str  |  int]  |  list[str  |  int]]
+           The serialized Issue as a JSON-compatible dictionary
+
+        Returns
+        -------
+        Issue
+            The deserialized Issue class instance
+
+        Raises
+        ------
+        TypeError
+            If the reason is not None or a string or if the identifiers are a string
+        """
+        serialized_type = serialized_issue["type"]
+        serialized_identifiers = serialized_issue["identifiers"]
+        serialized_reason = serialized_issue.get("reason")
+        if serialized_reason is not None and not isinstance(serialized_reason, str):
+            raise TypeError
+        if isinstance(serialized_identifiers, str):
+            raise TypeError
+
+        return Issue(
+            IssueType(serialized_type),
+            IssueIdentifiers.deserialize(serialized_identifiers)
+            if not isinstance(serialized_identifiers, list)
+            else serialized_identifiers,
+            serialized_reason,
+        )

--- a/tests/validation/test_issue.py
+++ b/tests/validation/test_issue.py
@@ -1,0 +1,266 @@
+# Copyright DB InfraGO AG and contributors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from uuid import UUID
+
+from raillabel_providerkit.validation import Issue, IssueIdentifiers, IssueType
+
+
+def test_issue_identifiers_serialize__empty():
+    identifiers = IssueIdentifiers()
+    assert identifiers.serialize() == {}
+
+
+def test_issue_identifiers_serialize__filled():
+    identifiers = IssueIdentifiers(
+        UUID("f9b8aa82-e42b-43df-85fb-99ab51145732"),
+        "likes_trains",
+        42,
+        UUID("6caf0a36-3872-4368-8d88-801593c7bc24"),
+        "person",
+        "rgb_center",
+    )
+    assert identifiers.serialize() == {
+        "annotation": "f9b8aa82-e42b-43df-85fb-99ab51145732",
+        "attribute": "likes_trains",
+        "frame": 42,
+        "object": "6caf0a36-3872-4368-8d88-801593c7bc24",
+        "object_type": "person",
+        "sensor": "rgb_center",
+    }
+
+
+def test_issue_identifiers_deserialize__empty():
+    identifiers = IssueIdentifiers.deserialize({})
+    assert identifiers.annotation is None
+    assert identifiers.attribute is None
+    assert identifiers.frame is None
+    assert identifiers.object is None
+    assert identifiers.object_type is None
+    assert identifiers.sensor is None
+
+
+def test_issue_identifiers_deserialize__filled():
+    identifiers = IssueIdentifiers.deserialize(
+        {
+            "annotation": "f9b8aa82-e42b-43df-85fb-99ab51145732",
+            "attribute": "likes_trains",
+            "frame": 42,
+            "object": "6caf0a36-3872-4368-8d88-801593c7bc24",
+            "object_type": "person",
+            "sensor": "rgb_center",
+        }
+    )
+    assert identifiers.annotation == UUID("f9b8aa82-e42b-43df-85fb-99ab51145732")
+    assert identifiers.attribute == "likes_trains"
+    assert identifiers.frame == 42
+    assert identifiers.object == UUID("6caf0a36-3872-4368-8d88-801593c7bc24")
+    assert identifiers.object_type == "person"
+    assert identifiers.sensor == "rgb_center"
+
+
+def test_issue_identifiers_deserialize__invalid_type_annotation():
+    with pytest.raises(TypeError):
+        IssueIdentifiers.deserialize(
+            {
+                "annotation": 42,
+            }
+        )
+
+
+def test_issue_identifiers_deserialize__invalid_type_attribute():
+    with pytest.raises(TypeError):
+        IssueIdentifiers.deserialize(
+            {
+                "attribute": 42,
+            }
+        )
+
+
+def test_issue_identifiers_deserialize__invalid_type_frame():
+    with pytest.raises(TypeError):
+        IssueIdentifiers.deserialize(
+            {
+                "frame": "the_first_frame",
+            }
+        )
+
+
+def test_issue_identifiers_deserialize__invalid_type_object():
+    with pytest.raises(TypeError):
+        IssueIdentifiers.deserialize(
+            {
+                "object": 42,
+            }
+        )
+
+
+def test_issue_identifiers_deserialize__invalid_type_object_type():
+    with pytest.raises(TypeError):
+        IssueIdentifiers.deserialize(
+            {
+                "object_type": 42,
+            }
+        )
+
+
+def test_issue_identifiers_deserialize__invalid_type_sensor():
+    with pytest.raises(TypeError):
+        IssueIdentifiers.deserialize(
+            {
+                "sensor": 42,
+            }
+        )
+
+
+def test_issue_serialize__simple():
+    issue = Issue(
+        IssueType.ATTRIBUTE_MISSING,
+        IssueIdentifiers(
+            UUID("f9b8aa82-e42b-43df-85fb-99ab51145732"),
+            "likes_trains",
+            42,
+            UUID("6caf0a36-3872-4368-8d88-801593c7bc24"),
+            "person",
+            "rgb_center",
+        ),
+        "some reason",
+    )
+    assert issue.serialize() == {
+        "type": "AttributeMissing",
+        "identifiers": {
+            "annotation": "f9b8aa82-e42b-43df-85fb-99ab51145732",
+            "attribute": "likes_trains",
+            "frame": 42,
+            "object": "6caf0a36-3872-4368-8d88-801593c7bc24",
+            "object_type": "person",
+            "sensor": "rgb_center",
+        },
+        "reason": "some reason",
+    }
+
+
+def test_issue_serialize__do_not_add_reason_if_none():
+    issue = Issue(
+        IssueType.ATTRIBUTE_MISSING,
+        IssueIdentifiers(
+            UUID("f9b8aa82-e42b-43df-85fb-99ab51145732"),
+            "likes_trains",
+            42,
+            UUID("6caf0a36-3872-4368-8d88-801593c7bc24"),
+            "person",
+            "rgb_center",
+        ),
+    )
+    assert issue.serialize() == {
+        "type": "AttributeMissing",
+        "identifiers": {
+            "annotation": "f9b8aa82-e42b-43df-85fb-99ab51145732",
+            "attribute": "likes_trains",
+            "frame": 42,
+            "object": "6caf0a36-3872-4368-8d88-801593c7bc24",
+            "object_type": "person",
+            "sensor": "rgb_center",
+        },
+    }
+
+
+def test_issue_serialize__schema_error():
+    issue = Issue(
+        IssueType.SCHEMA,
+        ["this", "is", "some", "schema", "error", 73],
+        "some reason",
+    )
+    assert issue.serialize() == {
+        "type": "SchemaIssue",
+        "identifiers": ["this", "is", "some", "schema", "error", 73],
+        "reason": "some reason",
+    }
+
+
+def test_issue_deserialize__simple():
+    issue = Issue.deserialize(
+        {
+            "type": "AttributeMissing",
+            "identifiers": {
+                "annotation": "f9b8aa82-e42b-43df-85fb-99ab51145732",
+                "attribute": "likes_trains",
+                "frame": 42,
+                "object": "6caf0a36-3872-4368-8d88-801593c7bc24",
+                "object_type": "person",
+                "sensor": "rgb_center",
+            },
+            "reason": "some reason",
+        }
+    )
+    assert issue.type == IssueType.ATTRIBUTE_MISSING
+    assert isinstance(issue.identifiers, IssueIdentifiers)
+    assert issue.identifiers.annotation == UUID("f9b8aa82-e42b-43df-85fb-99ab51145732")
+    assert issue.identifiers.attribute == "likes_trains"
+    assert issue.identifiers.frame == 42
+    assert issue.identifiers.object == UUID("6caf0a36-3872-4368-8d88-801593c7bc24")
+    assert issue.identifiers.object_type == "person"
+    assert issue.identifiers.sensor == "rgb_center"
+    assert issue.reason == "some reason"
+
+
+def test_issue_deserialize__without_reason():
+    issue = Issue.deserialize(
+        {
+            "type": "AttributeMissing",
+            "identifiers": {
+                "annotation": "f9b8aa82-e42b-43df-85fb-99ab51145732",
+                "attribute": "likes_trains",
+                "frame": 42,
+                "object": "6caf0a36-3872-4368-8d88-801593c7bc24",
+                "object_type": "person",
+                "sensor": "rgb_center",
+            },
+        }
+    )
+    assert issue.type == IssueType.ATTRIBUTE_MISSING
+    assert isinstance(issue.identifiers, IssueIdentifiers)
+    assert issue.identifiers.annotation == UUID("f9b8aa82-e42b-43df-85fb-99ab51145732")
+    assert issue.identifiers.attribute == "likes_trains"
+    assert issue.identifiers.frame == 42
+    assert issue.identifiers.object == UUID("6caf0a36-3872-4368-8d88-801593c7bc24")
+    assert issue.identifiers.object_type == "person"
+    assert issue.identifiers.sensor == "rgb_center"
+    assert issue.reason is None
+
+
+def test_issue_deserialize__schema_error():
+    issue = Issue.deserialize(
+        {
+            "type": "SchemaIssue",
+            "identifiers": ["this", "is", "some", "schema", "error", 73],
+            "reason": "some reason",
+        }
+    )
+    assert issue.type == IssueType.SCHEMA
+    assert isinstance(issue.identifiers, list)
+    assert issue.identifiers == ["this", "is", "some", "schema", "error", 73]
+    assert issue.reason == "some reason"
+
+
+def test_issue_deserialize__invalid_reason_type():
+    with pytest.raises(TypeError):
+        Issue.deserialize(
+            {
+                "type": "SchemaIssue",
+                "identifiers": ["ignore"],
+                "reason": ["wait", "that's", "illegal"],
+            }
+        )
+
+
+def test_issue_deserialize__invalid_identifiers_type():
+    with pytest.raises(TypeError):
+        Issue.deserialize(
+            {
+                "type": "SchemaIssue",
+                "identifiers": "A simple string is forbidden",
+                "reason": "ignore",
+            }
+        )


### PR DESCRIPTION
This PR adds a CLI interface to raillabel-providerkit, located in raillabel_providerkit/__main__.py. This allows for bulk validation of a folder full of scenes (and any subfolders). The detected issues are output into an output folder in .json format by default (and optionally .csv).

The interface can be called like this:

```py
python -m raillabel_providerkit /path/to/scene_folder_containing_all_scenes /path/to/output_folder --ontology /path/to/project_ontology.yaml
```

Additional optional parameters (for now) are:

- `--csv` to output the issues in .csv format (in addition to .json, if not disabled)
- `--no-json` to not output the issues in .json format (so in combination with `--csv`, only .csv is output)

I would like feedback on the following before removing the Draft state:

- If no ontology is given, we default to OSDaR23's ontology. Is this okay? Should we move the OSDaR23 ontology out of the testing assets folder?
- Only the validation functionality is exposed via the CLI. Should we add the other functionalities as well? Alternatively, should we move the validation `__main__.py` into `raillabel_providerkit.validation`, which would change the call to `python -m raillabel_providerkit.validation ...`?